### PR TITLE
Filter nested projects from the root project

### DIFF
--- a/.project
+++ b/.project
@@ -8,4 +8,15 @@
 	</buildSpec>
 	<natures>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1680084902701</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-projectRelativePath-matches-true-true-releng/org.eclipse.epp.config/.*|packages/[^/]+/.*</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>


### PR DESCRIPTION
Filter so that the nested project folder is visible, but not the contents under that folder.  This helps avoid search finding multiple hits for what is effectively the same underlying resource.