### PR TITLE
Include org.eclipse.pde.spies in products that include org.eclipse.pde

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -241,11 +241,13 @@ United States, other countries, or both.
       <feature id="org.eclipse.jdt" installMode="root"/>
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.pde" installMode="root"/>
+      <feature id="org.eclipse.pde.spies" installMode="root"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.platform.source" installMode="root"/>
       <feature id="org.eclipse.rcp.source" installMode="root"/>
       <feature id="org.eclipse.jdt.source" installMode="root"/>
       <feature id="org.eclipse.pde.source" installMode="root"/>
+      <feature id="org.eclipse.pde.spies.source" installMode="root"/>
       <feature id="org.eclipse.buildship" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.committers.product/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/p2.inf
@@ -169,3 +169,11 @@ requires.123.filter = (org.eclipse.epp.install.roots=true)
 requires.124.namespace = org.eclipse.equinox.p2.iu
 requires.124.name = org.eclipse.jdt.bcoview.feature.feature.group
 requires.124.filter = (org.eclipse.epp.install.roots=true)
+
+requires.125.namespace = org.eclipse.equinox.p2.iu
+requires.125.name = org.eclipse.pde.spies.feature.group
+requires.125.filter = (org.eclipse.epp.install.roots=true)
+
+requires.126.namespace = org.eclipse.equinox.p2.iu
+requires.126.name = org.eclipse.pde.spies.source.feature.group
+requires.126.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -257,6 +257,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.ocl.all.sdk" installMode="root"/>
       <feature id="org.eclipse.pde" installMode="root"/>
+      <feature id="org.eclipse.pde.spies" installMode="root"/>
       <feature id="org.eclipse.sdk" installMode="root"/>
       <feature id="org.eclipse.uml2.sdk" installMode="root"/>
       <feature id="org.eclipse.xsd.sdk" installMode="root"/>

--- a/packages/org.eclipse.epp.package.modeling.product/p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/p2.inf
@@ -194,3 +194,8 @@ requires.130.namespace = org.eclipse.equinox.p2.iu
 requires.130.name = org.eclipse.jdt.bcoview.feature.feature.group
 requires.130.filter = (org.eclipse.epp.install.roots=true)
 
+requires.131.namespace = org.eclipse.equinox.p2.iu
+requires.131.name = org.eclipse.pde.spies.feature.group
+requires.131.filter = (org.eclipse.epp.install.roots=true)
+
+

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -240,6 +240,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.pde"/>
+      <feature id="org.eclipse.pde.spies"/>
       <feature id="org.eclipse.platform.source"/>
       <feature id="org.eclipse.rcp.source"/>
       <feature id="org.eclipse.buildship" installMode="root"/>


### PR DESCRIPTION
Include this for the committers, modeling, and rcp products where I expect such spies will be significantly useful, but not for jee.

https://github.com/eclipse-pde/eclipse.pde/pull/479