### PR TITLE
Prepare repo for 2023-06 M1

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -38,11 +38,11 @@
     <!-- Name of the release (no milestone) -->
     <RELEASE_NAME>2023-06</RELEASE_NAME>
     <!-- Name of the milestone -->
-    <RELEASE_MILESTONE>RC1</RELEASE_MILESTONE>
+    <RELEASE_MILESTONE>M1</RELEASE_MILESTONE>
     <!-- Version of the release -->
     <RELEASE_VERSION>4.28.0</RELEASE_VERSION>
     <!-- Name release directory on download.eclipse.org -->
-    <RELEASE_DIR>202303021200</RELEASE_DIR>
+    <RELEASE_DIR>202304121200</RELEASE_DIR>
     <!-- SimRel Repo to build from -->
     <SIMREL_REPO>https://download.eclipse.org/staging/2023-06</SIMREL_REPO>
     <!-- ID used to generate the filename of the packages -->
@@ -54,9 +54,9 @@
     <!-- eclipse.simultaneous.release.name value for non-R builds -->
     <eclipse.simultaneous.release.name>${RELEASE_NAME} ${RELEASE_MILESTONE} (${RELEASE_VERSION} ${RELEASE_MILESTONE})</eclipse.simultaneous.release.name>
     <!-- eclipse.simultaneous.release.name value for R builds -->
-    <!-- <eclipse.simultaneous.release.name>${RELEASE_NAME} (${RELEASE_VERSION})</eclipse.simultaneous.release.name> -->
+    <eclipse.simultaneous.release.name>${RELEASE_NAME} (${RELEASE_VERSION})</eclipse.simultaneous.release.name>
     <!-- Upstream p2 repository, used as a source for pre-compiled build artifacts -->
-    <eclipse.simultaneous.release.repository>${SIMREL_REPO}</eclipse.simultaneous.release.repository>
+    <!-- <eclipse.simultaneous.release.repository>${SIMREL_REPO}</eclipse.simultaneous.release.repository> -->
   </properties>
 
   <prerequisites>

--- a/releng/org.eclipse.epp.config/tools/promote-a-build.sh
+++ b/releng/org.eclipse.epp.config/tools/promote-a-build.sh
@@ -73,7 +73,8 @@ cat > release.xml <<EOM
 <past>2022-03/R</past>
 <past>2022-06/R</past>
 <past>2022-09/R</past>
-<present>2022-12/R</present>
+<past>2022-12/R</past>
+<present>2023-03/R</present>
 <future>${RELEASE_NAME}/${RELEASE_MILESTONE}</future>
 </packages>
 EOM


### PR DESCRIPTION
I had previously done part of this before moving to GitHub but I had not gone through the checklist, so I am now filling in the missing items.

See also https://git.eclipse.org/r/c/epp/org.eclipse.epp.packages/+/200572

Part of #5