### PR TITLE
Add Mylyn to EPP packages

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.committers.feature" version="4.28.0.qualifier"/>
@@ -258,6 +262,8 @@ United States, other countries, or both.
       <feature id="org.eclipse.swt.tools.feature" installMode="root"/>
       <feature id="org.eclipse.wildwebdeveloper.feature" installMode="root"/>
       <feature id="org.eclipse.wildwebdeveloper.embedder.node.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.committers.product/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/p2.inf
@@ -177,3 +177,27 @@ requires.125.filter = (org.eclipse.epp.install.roots=true)
 requires.126.namespace = org.eclipse.equinox.p2.iu
 requires.126.name = org.eclipse.pde.spies.source.feature.group
 requires.126.filter = (org.eclipse.epp.install.roots=true)
+
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+
+requires.205.namespace = org.eclipse.equinox.p2.iu
+requires.205.name = org.eclipse.mylyn.pde_feature.feature.group
+requires.205.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.cpp.feature" version="4.28.0.qualifier"/>
@@ -266,6 +270,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.tracecompass.lttng2.control" installMode="root"/>
       <feature id="org.eclipse.tracecompass.lttng2.kernel" installMode="root"/>
       <feature id="org.eclipse.tracecompass.lttng2.ust" installMode="root"/>
+      <feature id="org.eclipse.cdt.mylyn" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.cpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.cpp.product/p2.inf
@@ -202,3 +202,23 @@ requires.132.namespace = org.eclipse.equinox.p2.iu
 requires.132.name = org.eclipse.tracecompass.lttng2.ust.feature.group
 requires.132.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.cdt.mylyn.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.dsl.feature" version="4.28.0.qualifier"/>
@@ -248,6 +252,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
       <feature id="org.eclipse.buildship" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.dsl.product/p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/p2.inf
@@ -142,3 +142,22 @@ requires.117.namespace = org.eclipse.equinox.p2.iu
 requires.117.name = org.eclipse.buildship.feature.group
 requires.117.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.embedcpp.feature" version="4.28.0.qualifier"/>
@@ -279,6 +283,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.embedcdt.templates.stm" installMode="root"/>
       <feature id="org.eclipse.embedcdt.templates.sifive" installMode="root"/>
       <feature id="org.eclipse.embedcdt.templates.xpack" installMode="root"/>
+      <feature id="org.eclipse.cdt.mylyn" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
@@ -266,3 +266,23 @@ requires.148.namespace = org.eclipse.equinox.p2.iu
 requires.148.name = org.eclipse.embedcdt.templates.xpack.feature.group
 requires.148.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.cdt.mylyn.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.java.feature" version="4.28.0.qualifier"/>
@@ -246,6 +250,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
       <feature id="org.eclipse.wildwebdeveloper.xml.feature" installMode="root"/>
       <feature id="org.eclipse.tips.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.java.product/p2.inf
+++ b/packages/org.eclipse.epp.package.java.product/p2.inf
@@ -134,3 +134,23 @@ requires.115.namespace = org.eclipse.equinox.p2.iu
 requires.115.name = org.eclipse.jdt.bcoview.feature.feature.group
 requires.115.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.jee.feature" version="4.28.0.qualifier"/>
@@ -312,6 +316,8 @@ United States, other countries, or both.
       <feature id="org.eclipse.wildwebdeveloper.feature" installMode="root"/>
       <feature id="org.eclipse.wildwebdeveloper.embedder.node.feature" installMode="root"/>
       <feature id="org.eclipse.tips.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.jee.product/p2.inf
+++ b/packages/org.eclipse.epp.package.jee.product/p2.inf
@@ -398,3 +398,26 @@ requires.181.namespace = org.eclipse.equinox.p2.iu
 requires.181.name = org.eclipse.jdt.bcoview.feature.feature.group
 requires.181.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+
+requires.205.namespace = org.eclipse.equinox.p2.iu
+requires.205.name = org.eclipse.mylyn.pde_feature.feature.group
+requires.205.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.modeling.feature" version="4.28.0.qualifier"/>
@@ -262,6 +266,8 @@ United States, other countries, or both.
       <feature id="org.eclipse.uml2.sdk" installMode="root"/>
       <feature id="org.eclipse.xsd.sdk" installMode="root"/>
       <feature id="org.eclipse.tips.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.modeling.product/p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/p2.inf
@@ -198,4 +198,28 @@ requires.131.namespace = org.eclipse.equinox.p2.iu
 requires.131.name = org.eclipse.pde.spies.feature.group
 requires.131.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+
+requires.205.namespace = org.eclipse.equinox.p2.iu
+requires.205.name = org.eclipse.mylyn.pde_feature.feature.group
+requires.205.filter = (org.eclipse.epp.install.roots=true)
+
 

--- a/packages/org.eclipse.epp.package.parallel.product/epp.product
+++ b/packages/org.eclipse.epp.package.parallel.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.parallel.feature" version="4.28.0.qualifier"/>
@@ -255,6 +259,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.remote.console" installMode="root"/>
       <feature id="org.eclipse.remote.proxy"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
+      <feature id="org.eclipse.cdt.mylyn" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.parallel.product/p2.inf
+++ b/packages/org.eclipse.epp.package.parallel.product/p2.inf
@@ -166,3 +166,22 @@ requires.123.namespace = org.eclipse.equinox.p2.iu
 requires.123.name = org.eclipse.wst.xml_ui.feature.feature.group
 requires.123.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.cdt.mylyn.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.php.feature" version="4.28.0.qualifier"/>

--- a/packages/org.eclipse.epp.package.php.product/p2.inf
+++ b/packages/org.eclipse.epp.package.php.product/p2.inf
@@ -134,3 +134,19 @@ requires.115.namespace = org.eclipse.equinox.p2.iu
 requires.115.name = org.eclipse.wildwebdeveloper.embedder.node.feature.feature.group
 requires.115.filter = (org.eclipse.epp.install.roots=true)
 
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.rcp.feature" version="4.28.0.qualifier"/>
@@ -258,6 +262,8 @@ United States, other countries, or both.
       <feature id="org.eclipse.swtbot.ide" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
       <feature id="org.eclipse.passage.ldc.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.rcp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/p2.inf
@@ -165,3 +165,27 @@ requires.122.filter = (org.eclipse.epp.install.roots=true)
 requires.123.namespace = org.eclipse.equinox.p2.iu
 requires.123.name = org.eclipse.pde.spies.feature.group
 requires.123.filter = (org.eclipse.epp.install.roots=true)
+
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)
+
+requires.205.namespace = org.eclipse.equinox.p2.iu
+requires.205.name = org.eclipse.mylyn.pde_feature.feature.group
+requires.205.filter = (org.eclipse.epp.install.roots=true)

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -234,6 +234,10 @@ United States, other countries, or both.
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.reviews.feature" installMode="root"/>
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.scout.feature" version="4.28.0.qualifier"/>
@@ -247,6 +251,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.scout.sdk-feature" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
       <feature id="org.eclipse.wst.web_ui.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
    </features>
 
 

--- a/packages/org.eclipse.epp.package.scout.product/p2.inf
+++ b/packages/org.eclipse.epp.package.scout.product/p2.inf
@@ -137,3 +137,23 @@ requires.115.filter = (org.eclipse.epp.install.roots=true)
 requires.116.namespace = org.eclipse.equinox.p2.iu
 requires.116.name = org.eclipse.jdt.bcoview.feature.feature.group
 requires.116.filter = (org.eclipse.epp.install.roots=true)
+
+requires.200.namespace = org.eclipse.equinox.p2.iu
+requires.200.name = org.eclipse.mylyn.ide_feature.feature.group
+requires.200.filter = (org.eclipse.epp.install.roots=true)
+
+requires.201.namespace = org.eclipse.equinox.p2.iu
+requires.201.name = org.eclipse.mylyn.git.feature.group
+requires.201.filter = (org.eclipse.epp.install.roots=true)
+
+requires.202.namespace = org.eclipse.equinox.p2.iu
+requires.202.name = org.eclipse.mylyn.hudson.feature.group
+requires.202.filter = (org.eclipse.epp.install.roots=true)
+
+requires.203.namespace = org.eclipse.equinox.p2.iu
+requires.203.name = org.eclipse.mylyn.reviews.feature.feature.group
+requires.203.filter = (org.eclipse.epp.install.roots=true)
+
+requires.204.namespace = org.eclipse.equinox.p2.iu
+requires.204.name = org.eclipse.mylyn.java_feature.feature.group
+requires.204.filter = (org.eclipse.epp.install.roots=true)


### PR DESCRIPTION
Summary of how and why I have added MyLyn to EPPs.

Below is all the mylyn features in 2023-06 M3 (not including wikitext stuff)

Included in all EPPs:

- org.eclipse.mylyn.ide_feature
- org.eclipse.mylyn.git
- org.eclipse.mylyn.hudson
- org.eclipse.mylyn.reviews.feature

Indirectly included in all EPPs because of a dependency chain starting above:

- org.eclipse.mylyn_feature
  - included as part of context_feature
- org.eclipse.mylyn.builds
  - included as part of mylyn_feature
- org.eclipse.mylyn.commons
  - included as part of mylyn_feature
- org.eclipse.mylyn.commons.identity
  - included as part of mylyn_feature
- org.eclipse.mylyn.commons.notifications
  - included as part of mylyn_feature
- org.eclipse.mylyn.commons.repositories
  - included as part of mylyn_feature
- org.eclipse.mylyn.commons.repositories.http
  - included as part of hudson
- org.eclipse.mylyn.context_feature
  - included as part of ide_feature
- org.eclipse.mylyn.discovery
  - included as part of mylyn_feature
- org.eclipse.mylyn.monitor
  - included as part of mylyn_feature
- org.eclipse.mylyn.tasks.ide
  - included as part of ide_feature
- org.eclipse.mylyn.team_feature
  - included as part of ide_feature
- org.eclipse.mylyn.versions
  - included as part of git

The following are in some of the EPPs, based on listed condition

- org.eclipse.mylyn.java_feature
  - if JDT is included
- org.eclipse.mylyn.pde_feature
  - if PDE is included
- org.eclipse.cdt.mylyn
  - if CDT is included

The following are not part of any of the EPPs, but can be installed from SimRel

- org.eclipse.mylyn.gerrit.dashboard.feature
- org.eclipse.mylyn.gerrit.feature
- org.eclipse.mylyn.trac_feature

Fixes #19