### PR TITLE
Add latest release update-site of m2eclipse

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu

--- a/packages/org.eclipse.epp.package.dsl.product/p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu

--- a/packages/org.eclipse.epp.package.java.product/p2.inf
+++ b/packages/org.eclipse.epp.package.java.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu

--- a/packages/org.eclipse.epp.package.jee.product/p2.inf
+++ b/packages/org.eclipse.epp.package.jee.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu

--- a/packages/org.eclipse.epp.package.rcp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu

--- a/packages/org.eclipse.epp.package.scout.product/p2.inf
+++ b/packages/org.eclipse.epp.package.scout.product/p2.inf
@@ -3,6 +3,8 @@ addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/
 addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.28,name:The Eclipse Project Updates);\
 addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
 addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-06,name:2023-06);\
+addRepository(type:0,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
+addRepository(type:1,location:https${#58}//download.eclipse.org/technology/m2e/releases/latest,name:Eclipse IDE integration for Maven);\
   mkdir(path:${installFolder}/dropins);
 
 requires.1.namespace=org.eclipse.equinox.p2.iu


### PR DESCRIPTION
With m2eclipse we try to fix issues found as soon as possible and to regular releases also between the simrel-cycle, but many users can only benefit from that after a next quarterly release as they often just use the eclipse defaults, even though we ask users whenever possible to add the m2eclipse update sites, it seems more valuable to have these added by default so users get notified also between releases about new updates and we get a faster feedback-cycle.

This adds the m2e release update-site to all EPPs that include m2e in their product.

FYI @HannesWell @mickaelistria @akurtakov @fbricon as m2e always only uses API from the current GA Eclipse Release already for a while there won't be any issues for users to upgrade in-release and we hopefully will get user-feedback faster especially regressions like this:
- https://github.com/eclipse-m2e/m2e-core/pull/1416

what was discovers just to late to be included in Eclipse 2023-06, so even it was fixed fast and we cold perform a new release right now it will take too long to approach at the larger user-base.