### PR TITLE
Adapt Product attributes to latest PDE Product-Editor enhancements

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for Eclipse Committers" uid="epp.package.committers" id="org.eclipse.epp.package.committers.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for Eclipse Committers" uid="epp.package.committers" id="org.eclipse.epp.package.committers.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.committers/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for C/C++ Developers" uid="epp.package.cpp" id="org.eclipse.epp.package.cpp.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for C/C++ Developers" uid="epp.package.cpp" id="org.eclipse.epp.package.cpp.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.cpp/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse DSL Tools" uid="epp.package.dsl" id="org.eclipse.epp.package.dsl.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse DSL Tools" uid="epp.package.dsl" id="org.eclipse.epp.package.dsl.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.dsl/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for Embedded C/C++ Developers" uid="epp.package.embedcpp" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for Embedded C/C++ Developers" uid="epp.package.embedcpp" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.embedcpp/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for Java Developers" uid="epp.package.java" id="org.eclipse.epp.package.java.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for Java Developers" uid="epp.package.java" id="org.eclipse.epp.package.java.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.java/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for Enterprise Java and Web Developers" uid="epp.package.jee" id="org.eclipse.epp.package.jee.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for Enterprise Java and Web Developers" uid="epp.package.jee" id="org.eclipse.epp.package.jee.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.jee/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse Modeling Tools" uid="epp.package.modeling" id="org.eclipse.epp.package.modeling.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse Modeling Tools" uid="epp.package.modeling" id="org.eclipse.epp.package.modeling.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.modeling/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.parallel.product/epp.product
+++ b/packages/org.eclipse.epp.package.parallel.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse for Scientific Computing" uid="epp.package.parallel" id="org.eclipse.epp.package.parallel.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse for Scientific Computing" uid="epp.package.parallel" id="org.eclipse.epp.package.parallel.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.parallel/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for PHP Developers" uid="epp.package.php" id="org.eclipse.epp.package.php.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse IDE for PHP Developers" uid="epp.package.php" id="org.eclipse.epp.package.php.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.php/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse for RCP and RAP Developers" uid="epp.package.rcp" id="org.eclipse.epp.package.rcp.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse for RCP and RAP Developers" uid="epp.package.rcp" id="org.eclipse.epp.package.rcp.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.rcp/eclipse_lg.png"/>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse for Scout Developers" uid="epp.package.scout" id="org.eclipse.epp.package.scout.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Eclipse for Scout Developers" uid="epp.package.scout" id="org.eclipse.epp.package.scout.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.scout/eclipse_lg.png"/>


### PR DESCRIPTION
Effectively this should not change the resulting product.

@jonahgraham btw. would it in general be interesting for EPP to use mixed products?
For each package I see a feature that only contains the branding plugin.
Would it be possible to include that branding plugin directly in the product or is it really required? The `epp.website.xml` of those features seems not to be included in the build binary artifacts, so it could actually be moved to the product or branding-plugin project.
Or would a change in this regard cause problems for updates?