### PR TITLE
Configure Plug-in Start Levels to enable slf4j-2 logging

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -60,6 +60,7 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -60,6 +60,7 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -60,6 +60,7 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.parallel.product/epp.product
+++ b/packages/org.eclipse.epp.package.parallel.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -60,6 +60,7 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -60,12 +61,14 @@
    </vm>
 
    <configurations>
+      <plugin id="org.apache.aries.spifly.dynamic.bundle" autoStart="true" startLevel="2" />
       <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />


### PR DESCRIPTION
Fixes https://github.com/eclipse-packaging/packages/issues/27

For all products this means that the implementation of the OSGi Service Loader Mediator Specification supplied by Eclipse-Platform, namly the 'org.apache.aries.spifly.dynamic.bundle' bundle has to be auto-started at level two, like it is already done for the Eclipse SDK managed by Eclipse-Platform.

All products that contain the slf4j.simple logging back-end, need to auto-start slf4j.simple as well.
Additionally a VM-property is set to turn slf4j.simple off by default. A user can then configure it as desired by modifying/setting the corresponding system-properties in the eclipse.ini, as defined in the SimpleLogger doc:
https://www.slf4j.org/api/org/slf4j/simple/SimpleLogger.html

If a product uses the o.e.m2e.logback feature, and therefore logback as logging back-end, nothing needs to be done. The m2e.logback feature already performs all necessary configuration upon its installation.

For the products that don't include m2e.logback this is the same change like it was done with the following two changes
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1195
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1252

At the moment I just opened this as a draft since the following changes are still pending and need to be contributed to SimRel in order to make the logging fully functional:
- [x] https://github.com/eclipse-rap/org.eclipse.rap.tools/pull/49
- [x] https://bugs.eclipse.org/bugs/show_bug.cgi?id=582259
- [x] https://git.eclipse.org/r/c/simrel/org.eclipse.simrel.build/+/203728

Theoretically we could already merge this even before the mentioned issues are resolved respectively before the solution is contributed to SimRel, but we could only verify if it really works afterwards.