### PR TITLE
Add slf4j configuration for php, committers and scout

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for Eclipse Committers" uid="epp.package.committers" id="org.eclipse.epp.package.committers.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse IDE for Eclipse Committers" uid="epp.package.committers" id="org.eclipse.epp.package.committers.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.committers/eclipse_lg.png"/>
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -67,6 +68,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
@@ -271,6 +273,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.mylyn.jdt.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.pde.feature" installMode="root"/>
    </features>
-
+   <plugins>
+      <plugin id="slf4j.api"/>
+      <plugin id="slf4j.simple"/>
+   </plugins>
 
 </product>

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse IDE for PHP Developers" uid="epp.package.php" id="org.eclipse.epp.package.php.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse IDE for PHP Developers" uid="epp.package.php" id="org.eclipse.epp.package.php.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.php/eclipse_lg.png"/>
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -67,6 +68,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
@@ -259,6 +261,9 @@ United States, other countries, or both.
       <!-- disabled due to mylyn feature changes - needs to be reenabled once PDT makes corresponding changes -->
       <!-- <feature id="org.eclipse.php.mylyn" installMode="root"/> -->
    </features>
-
+   <plugins>
+      <plugin id="slf4j.api"/>
+      <plugin id="slf4j.simple"/>
+   </plugins>
 
 </product>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Eclipse for Scout Developers" uid="epp.package.scout" id="org.eclipse.epp.package.scout.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="features" includeLaunchers="true" autoIncludeRequirements="true">
+<product name="Eclipse for Scout Developers" uid="epp.package.scout" id="org.eclipse.epp.package.scout.product" application="org.eclipse.ui.ide.workbench" version="4.29.0.qualifier" type="mixed" includeLaunchers="true" autoIncludeRequirements="true">
 
    <aboutInfo>
       <image path="/org.eclipse.epp.package.scout/eclipse_lg.png"/>
@@ -23,6 +23,7 @@
 -Dosgi.instance.area.default=@user.home/eclipse-workspace
 -Dosgi.dataAreaRequiresExplicitInit=true
 -Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true
+-Dorg.slf4j.simpleLogger.defaultLogLevel=off
 -Dsun.java.command=Eclipse
 -Xms256m
 -Xmx2048m
@@ -67,6 +68,7 @@
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.p2.reconciler.dropins" autoStart="true" startLevel="4" />
       <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1" />
+      <plugin id="slf4j.simple" autoStart="true" startLevel="2" />
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
@@ -259,6 +261,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.wst.web_ui.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.jdt.feature" installMode="root"/>
    </features>
-
+   <plugins>
+      <plugin id="slf4j.api"/>
+      <plugin id="slf4j.simple"/>
+   </plugins>
 
 </product>


### PR DESCRIPTION
Because the slf4j.simple is not included "naturally" by any of the features already in php, committers or scout, include it explicitly here.

Includes revert "Don't add slf4j.simple to products that don't include slf4j already" This reverts commit a1969248c1f9b76ed4c6d71d59f7965bb3e42bf2.

Fixes https://github.com/eclipse-packaging/packages/issues/27