### PR TITLE
Move more product configuration from p2.inf to product-file

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -278,5 +280,10 @@ United States, other countries, or both.
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <plugin id="slf4j.simple"/>
    </plugins>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.committers.product/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.committers.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.committers.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.committers.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.committers.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.committers.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.committers.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.committers
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Committers package.

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -282,5 +284,10 @@ United States, other countries, or both.
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <plugin id="slf4j.simple"/>
    </plugins>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.cpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.cpp.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.cpp.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.cpp.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.cpp.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.cpp.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.cpp.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.cpp.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.cpp
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse C/C++ Developers Developers package.

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -71,6 +71,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -253,5 +255,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.buildship" installMode="root"/>
    </features>
 
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.dsl.product/p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.dsl.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.dsl.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.dsl.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.dsl.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.dsl.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.dsl.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.dsl
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse DSL Tools package.

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -298,5 +300,10 @@ United States, other countries, or both.
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <plugin id="slf4j.simple"/>
    </plugins>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.embedcpp.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.embedcpp.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.embedcpp.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.embedcpp.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.embedcpp.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.embedcpp.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.embedcpp
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Embedded C/C++ Developers Developers package.

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -71,6 +71,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -261,5 +263,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.mylyn.jdt.feature" installMode="root"/>
    </features>
 
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.java.product/p2.inf
+++ b/packages/org.eclipse.epp.package.java.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.java.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.java.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.java.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.java.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.java.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.java.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.java
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Java Developers package.

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -71,6 +71,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -328,5 +330,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.mylyn.pde.feature" installMode="root"/>
    </features>
 
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.jee.product/p2.inf
+++ b/packages/org.eclipse.epp.package.jee.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.jee.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.jee.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.jee.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.jee.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.jee.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.jee.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.jee
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Enterprise Java and Web Developers package.

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -283,5 +285,9 @@ United States, other countries, or both.
       <plugin id="slf4j.simple"/>
    </plugins>
 
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.modeling.product/p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.modeling.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.modeling.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.modeling.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.modeling.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.modeling.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.modeling.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.modeling
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Modeling Tools package.

--- a/packages/org.eclipse.epp.package.parallel.product/epp.product
+++ b/packages/org.eclipse.epp.package.parallel.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -279,7 +281,10 @@ United States, other countries, or both.
       <targetfile overwrite="false"/>
    </preferencesInfo>
 
-   <cssInfo>
-   </cssInfo>
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>
+

--- a/packages/org.eclipse.epp.package.parallel.product/p2.inf
+++ b/packages/org.eclipse.epp.package.parallel.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.parallel.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.parallel.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.parallel.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.parallel.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.parallel.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.parallel.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.parallel
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse IDE for Scientific Computing package.

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -265,5 +267,10 @@ United States, other countries, or both.
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <plugin id="slf4j.simple"/>
    </plugins>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.php.product/p2.inf
+++ b/packages/org.eclipse.epp.package.php.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.php.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.php.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.php.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.php.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.php.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.php.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.php
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse PHP Developers package.

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -71,6 +71,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -274,5 +276,9 @@ United States, other countries, or both.
       <feature id="org.eclipse.mylyn.pde.feature" installMode="root"/>
    </features>
 
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.rcp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.rcp.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.rcp.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.rcp.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.rcp.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.rcp.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.rcp.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.rcp
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse RCP/RAP Developers package.

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -73,6 +73,8 @@
       <property name="org.eclipse.update.reconcile" value="false" />
       <property name="eclipse.buildId" value="${unqualifiedVersion}.${buildQualifier}" />
       <property name="osgi.bundles.defaultStartLevel" value="4" />
+      <property name="osgi.instance.area.default" value="@user.home/workspace" />
+      <property name="osgi.instance.area.default" value="@user.home/Documents/workspace" os="macosx" />
    </configurations>
 
    <license>
@@ -266,5 +268,10 @@ United States, other countries, or both.
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <plugin id="slf4j.simple"/>
    </plugins>
+
+   <repositories>
+      <repository location="https://download.eclipse.org/eclipse/updates/4.30" name="The Eclipse Project Updates" enabled="true" />
+      <repository location="https://download.eclipse.org/releases/2023-12" name="2023-12" enabled="true" />
+   </repositories>
 
 </product>

--- a/packages/org.eclipse.epp.package.scout.product/p2.inf
+++ b/packages/org.eclipse.epp.package.scout.product/p2.inf
@@ -1,45 +1,5 @@
 instructions.configure=\
-addRepository(type:0,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/eclipse/updates/4.30,name:The Eclipse Project Updates);\
-addRepository(type:0,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
-addRepository(type:1,location:https${#58}//download.eclipse.org/releases/2023-12,name:2023-12);\
   mkdir(path:${installFolder}/dropins);
-
-requires.1.namespace=org.eclipse.equinox.p2.iu
-requires.1.name=toolingorg.eclipse.epp.scout.configuration.macosx
-requires.1.filter=(osgi.os=macosx)
-requires.1.range=[1.0.0,1.0.0]
-requires.1.greedy=true
-
-requires.2.namespace=org.eclipse.equinox.p2.iu
-requires.2.name=toolingorg.eclipse.epp.scout.configuration
-requires.2.filter=(!(osgi.os=macosx))
-requires.2.range=[1.0.0,1.0.0]
-requires.2.greedy=true
-
-units.1.id=toolingorg.eclipse.epp.scout.configuration.macosx
-units.1.version=1.0.0
-units.1.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.1.provides.1.name=toolingorg.eclipse.epp.scout.configuration.macosx
-units.1.provides.1.version=1.0.0
-units.1.filter=(osgi.os=macosx)
-units.1.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.1.touchpoint.version=1.0.0
-units.1.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/Documents/workspace);
-#ln(linkTarget:Eclipse.app/Contents/MacOS/eclipse,targetDir:${installFolder},linkName:eclipse,force:true);
-units.1.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
-#org.eclipse.equinox.p2.touchpoint.natives.remove(path:${installFolder}/eclipse);
-
-units.2.id=toolingorg.eclipse.epp.scout.configuration
-units.2.version=1.0.0
-units.2.provides.1.namespace=org.eclipse.equinox.p2.iu
-units.2.provides.1.name=toolingorg.eclipse.epp.scout.configuration
-units.2.provides.1.version=1.0.0
-units.2.filter=(!(osgi.os=macosx))
-units.2.touchpoint.id=org.eclipse.equinox.p2.osgi
-units.2.touchpoint.version=1.0.0
-units.2.instructions.configure=setProgramProperty(propName:osgi.instance.area.default,propValue:@user.home/workspace);
-units.2.instructions.unconfigure=setProgramProperty(propName:osgi.instance.area.default,propValue:);
 
 # Bug 490515 - Prevent upgrade from old to new EPP package layout
 # https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
@@ -55,10 +15,6 @@ update.id = epp.package.scout
 update.range = [4.6.0.20160301-1200, $version$)
 update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
-# Set the product property type
-properties.0.name = org.eclipse.equinox.p2.type.product
-properties.0.value = true
 
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2023-12 Release of the Eclipse Scout Developers package.


### PR DESCRIPTION
And remove the unnecessary specification of the property `org.eclipse.equinox.p2.type.product=true`, which Tycho/P2 already set by default.

Similar to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1459.