### PR TITLE
Use Apache HTTP Client by default in EPP

### DIFF
--- a/packages/org.eclipse.epp.package.common.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.common.feature/feature.xml
@@ -19,6 +19,13 @@
       %license
    </license>
 
+   <requires>
+      <!-- Workaround Eclipse Platform default filetransfer not supporting authenticated proxies
+      See also the change in p2.inf
+      see https://github.com/eclipse-packaging/packages/issues/81 -->
+      <import feature="org.eclipse.ecf.filetransfer.httpclient5.feature"/>
+   </requires>
+
    <plugin
          id="org.eclipse.epp.package.common"
          download-size="0"

--- a/packages/org.eclipse.epp.package.common.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.common.feature/p2.inf
@@ -9,3 +9,12 @@ org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,location:https${#
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,location:https${#58}//download.eclipse.org/releases/latest,name:Latest Eclipse Simultaneous Release,enabled:true);\
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:0,location:https${#58}//download.eclipse.org/technology/epp/packages/latest/,name:Latest Eclipse IDE Packages Release,enabled:true);\
 org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(type:1,location:https${#58}//download.eclipse.org/technology/epp/packages/latest/,name:Latest Eclipse IDE Packages Release,enabled:true);\
+org.eclipse.equinox.p2.touchpoint.eclipse.addJvmArg(jvmArg:-Dorg.eclipse.ecf.provider.filetransfer.excludeContributors=org.eclipse.ecf.provider.filetransfer.httpclientjava);\
+
+
+# Workaround Eclipse Platform default filetransfer not supporting authenticated proxies
+# See also the change in p2.inf
+# see https://github.com/eclipse-packaging/packages/issues/81
+instructions.unconfigure= \
+org.eclipse.equinox.p2.touchpoint.eclipse.removeJvmArg(jvmArg:-Dorg.eclipse.ecf.provider.filetransfer.excludeContributors=org.eclipse.ecf.provider.filetransfer.httpclientjava);\
+


### PR DESCRIPTION
Fixes https://github.com/eclipse-packaging/packages/issues/81

This is reapplying the fix now that MPC has updated dependencies.