### PR TITLE
Prepare repo for 2023-03 M1 (fixup)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,7 +85,7 @@ This checklist is only used once per release cycle. Scroll down for the per-mile
   - [ ] Help -> About says expected build name and milestone, e.g. `2020-03-M2`
   - [ ] `org.eclipse.epp.package.*` features and bundles have the timestamp of the forced qualifier update or later
   - [ ] Upgrade from previous release works. To test the upgrade an equivalent to the simrel release composite site needs to done. Add the following software sites to available software, check for updates and then make sure stuff works. In particular check error log and that core features (Such as JDT, Platform) have been upgraded.
-    - `https://download.eclipse.org/staging/2023-12/` - _NOTE_ Use `SIMREL_REPO` if the staging repo has been updated since the `SIMREL_REPO` location was created.
+    - `https://download.eclipse.org/staging/2024-03/` - _NOTE_ Use `SIMREL_REPO` if the staging repo has been updated since the `SIMREL_REPO` location was created.
     - `https://download.eclipse.org/technology/epp/staging/repository/`
   - [ ] Verify no non-EPP content is in the p2 repo (especially justj, update [remove-justj-from-p2.xml](https://github.com/eclipse-packaging/packages/blob/master/releng/org.eclipse.epp.config/tools/remove-justj-from-p2.xml) if needed)
 - [ ] Edit the [Jenkins build](https://ci.eclipse.org/packaging/job/simrel.epp-tycho-build/)

--- a/packages/org.eclipse.epp.package.committers.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.committers.feature/epp.website.xml
@@ -34,6 +34,6 @@ Click <a href="https://github.com/eclipse-egit/egit/issues">here</a> to open a b
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-committers-2023-12-M1" />
+  <product name="eclipse-committers-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.committers.product/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Committers package.
+properties.1.value = 2024-03 Release of the Eclipse Committers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.cpp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.cpp.feature/epp.website.xml
@@ -22,6 +22,6 @@
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-cpp-2023-12-M1" />
+  <product name="eclipse-cpp-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.cpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.cpp.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse C/C++ Developers Developers package.
+properties.1.value = 2024-03 Release of the Eclipse C/C++ Developers Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.dsl.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.dsl.feature/epp.website.xml
@@ -27,6 +27,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-dsl-2023-12-M1" />
+  <product name="eclipse-dsl-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.dsl.product/p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse DSL Tools package.
+properties.1.value = 2024-03 Release of the Eclipse DSL Tools package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.embedcpp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.embedcpp.feature/epp.website.xml
@@ -29,6 +29,6 @@ To avoid compatibility issues with pre 6.x plug-ins, it is recommended to <b>cre
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-embedcpp-2023-12-M1" />
+  <product name="eclipse-embedcpp-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.embedcpp.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Embedded C/C++ Developers Developers package.
+properties.1.value = 2024-03 Release of the Eclipse Embedded C/C++ Developers Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.java.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.java.feature/epp.website.xml
@@ -28,6 +28,6 @@
 
 
 	<!-- name, the name of the product, used in naming the created files. -->
-	<product name="eclipse-java-2023-12-M1" />
+	<product name="eclipse-java-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.java.product/p2.inf
+++ b/packages/org.eclipse.epp.package.java.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Java Developers package.
+properties.1.value = 2024-03 Release of the Eclipse Java Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.jee.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.jee.feature/epp.website.xml
@@ -34,6 +34,6 @@ Click <a href="https://github.com/eclipse/wildwebdeveloper/issues">here</a> to r
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-jee-2023-12-M1" />
+  <product name="eclipse-jee-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.jee.product/p2.inf
+++ b/packages/org.eclipse.epp.package.jee.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Enterprise Java and Web Developers package.
+properties.1.value = 2024-03 Release of the Eclipse Enterprise Java and Web Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.modeling.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.modeling.feature/epp.website.xml
@@ -24,6 +24,6 @@
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-modeling-2023-12-M1" />
+  <product name="eclipse-modeling-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.modeling.product/p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Modeling Tools package.
+properties.1.value = 2024-03 Release of the Eclipse Modeling Tools package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.php.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.php.feature/epp.website.xml
@@ -35,6 +35,6 @@ Click <a href="https://github.com/eclipse/wildwebdeveloper/issues">here</a> to r
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-php-2023-12-M1" />
+  <product name="eclipse-php-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.php.product/p2.inf
+++ b/packages/org.eclipse.epp.package.php.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse PHP Developers package.
+properties.1.value = 2024-03 Release of the Eclipse PHP Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.rcp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.rcp.feature/epp.website.xml
@@ -27,6 +27,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-rcp-2023-12-M1" />
+  <product name="eclipse-rcp-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.rcp.product/p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse RCP/RAP Developers package.
+properties.1.value = 2024-03 Release of the Eclipse RCP/RAP Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/packages/org.eclipse.epp.package.scout.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.scout.feature/epp.website.xml
@@ -31,6 +31,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-scout-2023-12-M1" />
+  <product name="eclipse-scout-2024-03-M1" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.scout.product/p2.inf
+++ b/packages/org.eclipse.epp.package.scout.product/p2.inf
@@ -17,7 +17,7 @@ update.severity = 0
 update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
 
 properties.1.name = org.eclipse.equinox.p2.description
-properties.1.value = 2023-12 Release of the Eclipse Scout Developers package.
+properties.1.value = 2024-03 Release of the Eclipse Scout Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project

--- a/releng/org.eclipse.epp.config/build.xml
+++ b/releng/org.eclipse.epp.config/build.xml
@@ -41,7 +41,7 @@
 	            latestversiononly="false"/>
 	        <source>
 	                <sort>
-			            <fileset dir="/tmp/2023-12">
+			            <fileset dir="/tmp/2024-03">
     						<include name="*"/>
 						</fileset>
 						<reverse xmlns="antlib:org.apache.tools.ant.types.resources.comparators">
@@ -49,7 +49,7 @@
 						</reverse>
 	                </sort>
 	        </source>
-	        <destination location="${targetRepository}" name="EPP 2023-12 Package Repository" append="true" compressed="true" />
+	        <destination location="${targetRepository}" name="EPP 2024-03 Package Repository" append="true" compressed="true" />
 	    </p2.mirror>
 	</target>
 


### PR DESCRIPTION
Fixes missing version string updates. See https://github.com/eclipse-packaging/packages/issues/104#issuecomment-1889061846 for more details.