### PR TITLE
Allow all product requirements to be updated

### DIFF
--- a/packages/org.eclipse.epp.package.committers.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.committers.feature/feature.xml
@@ -20,20 +20,6 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"
-         search-location="both"/>
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
-
    <plugin
          id="org.eclipse.epp.package.committers"
          download-size="0"

--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
@@ -250,7 +249,6 @@ United States, other countries, or both.
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.committers.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.help"/>
       <feature id="org.eclipse.jdt" installMode="root"/>
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.pde" installMode="root"/>

--- a/packages/org.eclipse.epp.package.common.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.common.feature/feature.xml
@@ -20,6 +20,10 @@
    </license>
 
    <requires>
+      <!-- This ensures this feature cannot be uninstalled. It is installed with installMode="root" in the product --> 
+      <import feature="org.eclipse.platform" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.equinox.p2.user.ui"/>
+
       <!-- Workaround Eclipse Platform default filetransfer not supporting authenticated proxies
       See also the change in p2.inf
       see https://github.com/eclipse-packaging/packages/issues/81 -->

--- a/packages/org.eclipse.epp.package.cpp.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.cpp.feature/feature.xml
@@ -20,21 +20,6 @@
       %license
    </license>
 
-   <!-- see p2.inf file for optionally imported Linux Tools features -->
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-
-        The CPP package includes several features/IUs by the p2.inf file in
-        the CPP feature; this hasn't been touched and could be part of another
-        change.
-     -->
-
    <plugin
          id="org.eclipse.epp.package.cpp"
          download-size="0"

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.dsl.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.dsl.feature/feature.xml
@@ -20,20 +20,6 @@
       %license
    </license>
 
-   <requires>
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-
-        Since the DSL package already moved some of the dependencies to the product
-        definition, no need to change anything here.
-     -->
-   </requires>
-
    <plugin
          id="org.eclipse.epp.package.dsl"
          download-size="0"

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -227,8 +227,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.embedcpp.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.embedcpp.feature/feature.xml
@@ -22,19 +22,6 @@
 
    <!-- see p2.inf file for optionally imported Linux Tools features -->
 
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-
-        The Embedded CPP package includes several features/IUs by the p2.inf file in
-        the Embedded CPP feature; this hasn't been touched and could be part of another
-        change.
-     -->
-
    <plugin
          id="org.eclipse.epp.package.embedcpp"
          download-size="0"

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.java.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.java.feature/feature.xml
@@ -20,15 +20,6 @@
       %license
    </license>
 
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
-
    <plugin
          id="org.eclipse.epp.package.java"
          download-size="0"

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -227,8 +227,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.jee.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.jee.feature/feature.xml
@@ -20,81 +20,14 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"
-         search-location="both"/>
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-
-        Please note that there are some additional dependencies to certain
-        plugins defined within this feature; these dependencies haven't been
-        changed.
-     -->
-
-   <plugin
-         id="org.eclipse.epp.package.jee"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <!-- https://bugs.eclipse.org/bugs/show_bug.cgi?id=537117 decided to keep the intro and capabilities -->
-   <plugin
-         id="org.eclipse.wtp.epp.package.jee.intro"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-   <plugin
-         id="org.eclipse.wtp.javascript.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
-
-   <plugin
-         id="org.eclipse.wtp.jee.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
-
-   <plugin
-         id="org.eclipse.wtp.web.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
-
-   <plugin
-         id="org.eclipse.wtp.xml.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
-
-   <plugin
-         id="org.eclipse.wtp.epp.package.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>
-
-<!-- need to confirm if these plugins in repository, or if I need to cut/copy paste their contents in our capabilities plugin.
-See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=299344
- 
-   <plugin
-         id="org.eclipse.datatools.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
-
-   <plugin
-         id="org.eclipse.mylyn.ide.capabilities"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"/>   
--->
+   <!-- This ensures these feature cannot be uninstalled. They are installed with installMode="root" in the product --> 
+   <requires>
+      <import plugin="org.eclipse.wtp.epp.package.jee.intro"/>
+      <import plugin="org.eclipse.wtp.javascript.capabilities"/>
+      <import plugin="org.eclipse.wtp.jee.capabilities"/>
+      <import plugin="org.eclipse.wtp.web.capabilities"/>
+      <import plugin="org.eclipse.wtp.xml.capabilities"/>
+      <import plugin="org.eclipse.wtp.epp.package.capabilities"/>
+   </requires>
 
 </feature>

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -227,8 +227,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.modeling.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.modeling.feature/feature.xml
@@ -20,20 +20,6 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"
-         search-location="both"/>
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
-
    <plugin
          id="org.eclipse.epp.package.modeling"
          download-size="0"

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.php.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.php.feature/feature.xml
@@ -20,20 +20,6 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"
-         search-location="both"/>
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
-
    <plugin
          id="org.eclipse.epp.package.php"
          download-size="0"

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.rcp.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.rcp.feature/feature.xml
@@ -20,14 +20,12 @@
       %license
    </license>
 
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
+   <!-- This ensures these features cannot be uninstalled. They are installed with installMode="root" in the product --> 
+   <requires>
+      <import feature="org.eclipse.platform.source" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.jdt" version="3.0.0" match="compatible"/>
+      <import feature="org.eclipse.pde" version="3.0.0" match="compatible"/>
+   </requires>
 
    <plugin
          id="org.eclipse.epp.package.rcp"

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -227,8 +227,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
@@ -248,12 +247,12 @@ United States, other countries, or both.
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.rcp.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.jdt"/>
+      <feature id="org.eclipse.jdt" installMode="root"/>
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
-      <feature id="org.eclipse.pde"/>
+      <feature id="org.eclipse.pde" installMode="root"/>
       <feature id="org.eclipse.pde.spies" installMode="root"/>
-      <feature id="org.eclipse.platform.source"/>
-      <feature id="org.eclipse.rcp.source"/>
+      <feature id="org.eclipse.platform.source" installMode="root"/>
+      <feature id="org.eclipse.rcp.source" installMode="root"/>
       <feature id="org.eclipse.buildship" installMode="root"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.scout.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.scout.feature/feature.xml
@@ -20,20 +20,6 @@
       %license
    </license>
 
-   <includes
-         id="org.eclipse.platform"
-         version="0.0.0"
-         search-location="both"/>
-
-   <!--
-        All requirements to features and the content of the product are defined 
-        in the product configuration epp.product since Eclipse Neon. For further
-        details see the following bug:
-
-        Bug 332989 - Allow parts of a package to upgraded or removed
-        https://bugs.eclipse.org/bugs/show_bug.cgi?id=332989
-     -->
-
    <plugin
          id="org.eclipse.epp.package.scout"
          download-size="0"

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -229,8 +229,7 @@ United States, other countries, or both.
 
       <!-- common features that all products have -->
       <feature id="org.eclipse.epp.package.common.feature" version="4.32.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
-      <feature id="org.eclipse.equinox.p2.user.ui"/>
+      <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>


### PR DESCRIPTION
- Change all feature includes in products to be installMode="root".
- Add a requires/import to the corresponding product feature for each such modified feature include.
- Remove all references to org.eclipse.equinox.p2.user.ui and org.eclipse.help because these are included by org.eclipse.platform anyway.
- Change any non-epp plug-in include in a feature to a requires/import import, i.e., in the jee feature.xml.

https://github.com/eclipse-packaging/packages/issues/133