### PR TITLE
Use SmartImportGitWizard on Eclipse Scout intro-page

### DIFF
--- a/packages/org.eclipse.epp.package.scout/plugin.xml
+++ b/packages/org.eclipse.epp.package.scout/plugin.xml
@@ -104,7 +104,7 @@
             resolution="launchbar">
       </command>
       <command
-            id="org.eclipse.ui.file.import(importWizardId=org.eclipse.egit.ui.internal.clone.GitCloneWizard)"
+            id="org.eclipse.ui.file.import(importWizardId=org.eclipse.egit.ui.internal.clone.SmartImportGitWizard)"
             description="%ql.checkoutGitProject.description"
             icon="platform:/plugin/org.eclipse.ui.intro.universal/themes/solstice/graphics/icons/ctool/egit-checkout.png"
             label="%ql.checkoutGitProject.label"


### PR DESCRIPTION
This will update the intro page to start the SmartImportGitWizard (which we use for our test-procedure) instead of the GitCloneWizard. 