### PR TITLE
Restrict resource creation tasks in .github clone to exclude bootstrap

### DIFF
--- a/releng/org.eclipse.epp.config/oomph/EPP.setup
+++ b/releng/org.eclipse.epp.config/oomph/EPP.setup
@@ -135,6 +135,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="BOOTSTRAP"
       targetURL="${github.clone.epp.github.location|uri}/.gitignore">
     <content>
       .project
@@ -144,6 +145,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="BOOTSTRAP"
       targetURL="${github.clone.epp.github.location|uri}/.project">
     <content>
       &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?>
@@ -162,6 +164,7 @@
   </setupTask>
   <setupTask
       xsi:type="setup:ResourceCreationTask"
+      excludedTriggers="BOOTSTRAP"
       targetURL="${github.clone.epp.github.location|uri}/.settings/org.eclipse.core.resources.prefs">
     <content>
       eclipse.preferences.version=1


### PR DESCRIPTION
- This ensures the clone task runs first rather than failing because the folder is not empty.