### PR TITLE
Register eclipse+command / eclipse+mpc links for macOS packages

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -47,7 +47,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -47,7 +47,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -47,7 +47,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -47,7 +47,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -48,7 +48,12 @@
       startupForegroundColor="ffffff" />
    <launcher name="eclipse">
       <linux icon="../../icons/icon.xpm"/>
-      <macosx icon="../../icons/Eclipse.icns"/>
+      <macosx icon="../../icons/Eclipse.icns">
+         <bundleUrlTypes>
+            <bundleUrlType scheme="eclipse+command" name="Eclipse Command"/>
+            <bundleUrlType scheme="eclipse+mpc" name="Eclipse Marketplace"/>
+         </bundleUrlTypes>
+      </macosx>
       <win useIco="false">
          <bmp/>
       </win>


### PR DESCRIPTION
With https://github.com/eclipse-platform/eclipse.platform.ui/issues/1901 the auto-registration of link handlers was removed to avoid breaking of code signatures.

In order to use the 'eclipse+command' and 'eclipse+mpc' URI schemes on macOS, they must instead be pre-registered during .app bundle build time before code signing.