### PR TITLE
Produce packages for linux riscv64

### DIFF
--- a/releng/org.eclipse.epp.config/aggregation/packaging.aggr
+++ b/releng/org.eclipse.epp.config/aggregation/packaging.aggr
@@ -10,6 +10,7 @@
   </validationSets>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="aarch64"/>
   <configurations operatingSystem="linux" windowSystem="gtk" architecture="x86_64"/>
+  <configurations operatingSystem="linux" windowSystem="gtk" architecture="riscv64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="aarch64"/>
   <configurations operatingSystem="macosx" windowSystem="cocoa" architecture="x86_64"/>
   <configurations architecture="x86_64"/>

--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -55,7 +55,7 @@
     <!-- Used for the variable below to update easily, e.g., to 21. -->
     <execution.environment.version>21</execution.environment.version>
     <!-- Used for the JustJ JREs p2 repository. -->
-    <justj.jres.repository>https://download.eclipse.org/justj/jres/${execution.environment.version}/updates/release/latest</justj.jres.repository> <!-- Keep URL in sync with Oomph setup-->
+    <justj.jres.repository>https://download.eclipse.org/justj/jres/${execution.environment.version}/updates/milestone/latest</justj.jres.repository> <!-- Keep URL in sync with Oomph setup-->
     <!-- Used for the JustJ EPP p2 repository. -->
     <justj.epp.repository>https://download.eclipse.org/justj/epp/milestone/latest</justj.epp.repository> <!-- Keep URL in sync with Oomph setup-->
     <!-- The Justj execution enviroment for the target-platform-configuration. -->
@@ -139,6 +139,11 @@
               <os>linux</os>
               <ws>gtk</ws>
               <arch>aarch64</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
+              <arch>riscv64</arch>
             </environment>
             <environment>
               <os>win32</os>

--- a/releng/org.eclipse.epp.config/tools/upload-to-building.sh
+++ b/releng/org.eclipse.epp.config/tools/upload-to-building.sh
@@ -24,6 +24,7 @@ for PACKAGE in $PACKAGES; do
     # with an extra "tonotarize" on the macosx items
     NEWNAME=`echo ${NAME} | \
              sed 's/linux\.gtk\.aarch64/linux-gtk-aarch64/' | \
+             sed 's/linux\.gtk\.riscv64/linux-gtk-riscv64/' | \
              sed 's/linux\.gtk\.x86\_64/linux-gtk-x86\_64/' | \
              sed 's/win32\.win32\.x86\_64\./win32\-x86\_64\./' | \
              sed 's/macosx\.cocoa\.aarch64/macosx\-cocoa-aarch64/' | \


### PR DESCRIPTION
- Use the JustJ milestone JRE repo for Java 21 which has the required riscv64 JREs.
- Include linux-gtk-riscv64 in the target-platform-configuration.
- Add a linux-gtk-riscv64 configuration to the packaging.aggr.
- Improve upload-to-building.sh to produce a nice name for the new package.

https://github.com/eclipse-packaging/packages/issues/213