### PR TITLE
Specify VM options on Windows to use the system certificate store.

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.committers/eclipse16.png" i32="/org.eclipse.epp.package.committers/eclipse32.png" i48="/org.eclipse.epp.package.committers/eclipse48.png" i256="/org.eclipse.epp.package.committers/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.cpp/eclipse16.png" i32="/org.eclipse.epp.package.cpp/eclipse32.png" i48="/org.eclipse.epp.package.cpp/eclipse48.png" i256="/org.eclipse.epp.package.cpp/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -36,6 +36,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.dsl/eclipse16.png" i32="/org.eclipse.epp.package.dsl/eclipse32.png" i48="/org.eclipse.epp.package.dsl/eclipse48.png" i256="/org.eclipse.epp.package.dsl/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.embedcpp/eclipse16.png" i32="/org.eclipse.epp.package.embedcpp/eclipse32.png" i48="/org.eclipse.epp.package.embedcpp/eclipse48.png" i256="/org.eclipse.epp.package.embedcpp/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -36,6 +36,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.java/eclipse16.png" i32="/org.eclipse.epp.package.java/eclipse32.png" i48="/org.eclipse.epp.package.java/eclipse48.png" i256="/org.eclipse.epp.package.java/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -36,6 +36,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.jee/javaee-ide_x16.png" i32="/org.eclipse.epp.package.jee/javaee-ide_x32.png" i48="/org.eclipse.epp.package.jee/javaee-ide_x48.png"/>

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.modeling/eclipse16.png" i32="/org.eclipse.epp.package.modeling/eclipse32.png" i48="/org.eclipse.epp.package.modeling/eclipse48.png" i256="/org.eclipse.epp.package.modeling/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.php/eclipse16.png" i32="/org.eclipse.epp.package.php/eclipse32.png" i48="/org.eclipse.epp.package.php/eclipse48.png" i256="/org.eclipse.epp.package.php/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -36,6 +36,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.rcp/eclipse16.png" i32="/org.eclipse.epp.package.rcp/eclipse32.png" i48="/org.eclipse.epp.package.rcp/eclipse48.png" i256="/org.eclipse.epp.package.rcp/eclipse256.png"/>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -37,6 +37,9 @@
 -Dorg.eclipse.swt.internal.carbon.smallFonts
 -Xdock:icon=../Resources/Eclipse.icns
       </vmArgsMac>
+      <vmArgsWin>-Djavax.net.ssl.trustStoreType=Windows-ROOT
+-Djavax.net.ssl.trustStore=NONE
+      </vmArgsWin>
    </launcherArgs>
 
    <windowImages i16="/org.eclipse.epp.package.scout/eclipse16.png" i32="/org.eclipse.epp.package.scout/eclipse32.png" i48="/org.eclipse.epp.package.scout/eclipse48.png" i256="/org.eclipse.epp.package.scout/eclipse256.png"/>


### PR DESCRIPTION
- -Djavax.net.ssl.trustStoreType=Windows-ROOT
- -Djavax.net.ssl.trustStore=NONE

https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/929