### PR TITLE
Don't set LIBARCHIVE.creationtime attribute in tar.gz archives and update to Tycho 4.0.10

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -306,6 +306,7 @@
               <macosx>tar.gz</macosx>
               <win32>zip</win32>
             </formats>
+            <storeCreationTime>false</storeCreationTime>
             <products>
               <product>
                 <id>${project.artifactId}</id>


### PR DESCRIPTION
This PR includes two changes
1. Update to Tycho 4.0.10
2. Don't set `LIBARCHIVE.creationtime` attribute in `tar.gz` archives


The former change is required by the latter. The latter permanently
fixes https://github.com/eclipse-packaging/packages/issues/53

This is similar to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2530. See also https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2529.
And this probably also allows to remove the current workaround for https://github.com/eclipse-packaging/packages/issues/53.