### PR TITLE
[Build] Adapt Github workflows to parallel build and build with Maven 3.9.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Maven
       uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
       with:
-        maven-version: 3.9.2
+        maven-version: 3.9.9
     - name: Build with Maven
       run: mvn clean verify -B -Pepp.p2.${{ matrix.package }} -Pepp.product.${{ matrix.package }} -Pepp.p2.common
     - name: Upload bundle information

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         maven-version: 3.9.2
     - name: Build with Maven
-      run: mvn clean verify -Pepp.package.${{ matrix.package }}
+      run: mvn clean verify -B -Pepp.p2.${{ matrix.package }} -Pepp.product.${{ matrix.package }} -Pepp.p2.common
     - name: Upload bundle information
       uses: actions/upload-artifact@v3
       if: success() || failure()


### PR DESCRIPTION
Currently there are warnings in each element of the GH workflow matrix like:
`Warning:  The requested profile "epp.package.committers" could not be activated because it does not exist.`

and all packages are built in each build, which just takes much longer.

Part of https://github.com/eclipse-packaging/packages/issues/120