### PR TITLE
[Build] Materialize products in parallel

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -307,6 +307,7 @@
               <win32>zip</win32>
             </formats>
             <storeCreationTime>false</storeCreationTime>
+            <parallel>true</parallel>
             <products>
               <product>
                 <id>${project.artifactId}</id>


### PR DESCRIPTION
EPP currently builds all projects for seven different OS-arch combinations and all are build one after the other

Using the [`tycho-p2-director:materialize-products#parallel`](https://tycho.eclipseprojects.io/doc/4.0.10/tycho-p2-director-plugin/materialize-products-mojo.html#parallel) property the materialization for all configurations of one product can run in parallel which can speed up the build significantly.
After signing, the materialization is probably the longest running sub-task.