### PR TITLE
prepare repo for run up to 2024-12 RC2/R

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -47,9 +47,9 @@
     <!-- Human readable name of the release, e.g. used in the about dialog (see about.mappings) -->
     <!-- TODO the two alternative values of eclipse.simultaneous.release.name could be automated, perhaps with a profile dependent on RELEASE_MILESTONE -->
     <!-- eclipse.simultaneous.release.name value for non-R builds -->
-    <eclipse.simultaneous.release.name>${RELEASE_NAME} ${RELEASE_MILESTONE} (${RELEASE_VERSION} ${RELEASE_MILESTONE})</eclipse.simultaneous.release.name>
+    <!-- <eclipse.simultaneous.release.name>${RELEASE_NAME} ${RELEASE_MILESTONE} (${RELEASE_VERSION} ${RELEASE_MILESTONE})</eclipse.simultaneous.release.name> -->
     <!-- eclipse.simultaneous.release.name value for R builds -->
-    <!-- <eclipse.simultaneous.release.name>${RELEASE_NAME} (${RELEASE_VERSION})</eclipse.simultaneous.release.name> -->
+    <eclipse.simultaneous.release.name>${RELEASE_NAME} (${RELEASE_VERSION})</eclipse.simultaneous.release.name>
     <!-- Upstream p2 repository, used as a source for pre-compiled build artifacts -->
     <eclipse.simultaneous.release.repository>${SIMREL_REPO}</eclipse.simultaneous.release.repository>
     <!-- Used for the variable below to update easily, e.g., to 21. -->

--- a/releng/org.eclipse.epp.config/tools/promote-a-build.sh
+++ b/releng/org.eclipse.epp.config/tools/promote-a-build.sh
@@ -86,8 +86,8 @@ cat > release.xml <<EOM
 <past>2023-12/R</past>
 <past>2024-03/R</past>
 <past>2024-06/R</past>
-<present>2024-09/R</present>
-<future>${RELEASE_NAME}/${RELEASE_MILESTONE}</future>
+<past>2024-09/R</past>
+<present>2024-12/R</present>
 </packages>
 EOM
 $ECHO $SCP release.xml "${SSHUSER}:"${EPP_DOWNLOADS}/downloads/release/release.xml

--- a/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
+++ b/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
@@ -52,13 +52,13 @@ Please test and send your +1 to this mailing list. +1s are optional as the packa
 Last +1 received for each package and platform (apologies if I missed one of your +1 emails, just let me know and I will update Last Recorded +1)
 
 Packages:
-committers - 2024-09 RC1
-cpp - 2024-12 M1
-dsl - 2024-09 M3
+committers - 2024-12 M3
+cpp - 2024-12 M2
+dsl - 2024-12 M3
 embedcpp - 2024-09 RC2
 java - 2024-06 RC1
 jee - 2024-09 RC2
-modeling - 2024-09 RC1
+modeling - 2024-12 M2
 php - 2023-06 RC2
 rcp - 2024-09 RC1
 scout - 2024-09 RC2
@@ -66,9 +66,11 @@ scout - 2024-09 RC2
 Platforms:
 Linux x86_64 - 2024-09 RC2
 Linux aarch64 - 2023-09 RC2
-Windows - 2024-12 M1
+Linux riscv64 - 2024-12 M3
+Windows x86_64 - 2024-12 M2
+Windows on Arm - 2024-12 M3
 macOS x86_64 - 2024-09 RC2
-macOS aarch64 - 2024-09 M3
+macOS aarch64 - 2024-12 M3
 
 Thank you for testing!
 


### PR DESCRIPTION
Most of the work was already completed in commit c4446d0eac696691d555e0ed01c5a01a22bbb6af - this change does the last couple of steps up until "Wait for announcement that the staging repo is ready"

Part of #242