### PR TITLE
Update check incubation step

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,8 +36,12 @@ This checklist is only used once per release cycle. Scroll down for the per-mile
 - [ ] Make sure any outstanding [reviews](https://projects.eclipse.org/projects/technology.packaging/governance) are progressing - e.g. create progress review, get PMC approval, etc.
   - Annual progress review is normally done in early June
 - [ ] Ensure that the [CI build](https://ci.eclipse.org/packaging/job/epp/job/master/) is green. Resolving non-green builds will require tracking down problems and incompatibilities across all Eclipse participating projects. [cross-project-issues-dev](https://accounts.eclipse.org/mailing-list/cross-project-issues-dev) mailing list is a good place to start when tracking such problems.
-- [ ] Check that packages containing incubating projects have that information reflected in Help -> About dialog. See near the end of build output for report of check-incubating.sh script.
-  - `-incubation` and ` (includes Incubating components)` are not used in packageMetaData anymore (See [Bug 564214](https://bugs.eclipse.org/bugs/show_bug.cgi?id=564214))
+- [x] Check that packages containing incubating projects have that information reflected in Help -> About dialog. See near the end of build output for report of check-incubating.sh script.
+  - This item is not currently done per milestone/release because for a while now all packages contain incubating components and until TM4E moves out of incubation this step is redundant.
+  - The incubating indication should appear in feature.properties `description`, plugin.xml's product `aboutText` and about.properties `blurb`.
+  In the past `-incubation` had to appear in the file name and ` (includes Incubating components)` had to appear in `packageMetaData`.
+  See [Bug 564214](https://bugs.eclipse.org/bugs/show_bug.cgi?id=564214) for documentation/votes on decision making.
+
 - [ ] On RC1 check "new and noteworthy" version numbers - If any N&N are out of date, remove the N&N entries and notify the corresponding package maintainer.
   - [ ] Search for ` url=` (notice the blank before url) in `epp.website.xml` to see which ones are contained in the different packages.
   - [ ] Remember that some of the features will release new versions together with the new Eclipse release. Therefore using the _currently_ released version number may be wrong. Instead lookup the feature version [to be released with the release train](https://projects.eclipse.org/releases/).

--- a/packages/org.eclipse.epp.package.modeling/about.properties
+++ b/packages/org.eclipse.epp.package.modeling/about.properties
@@ -16,7 +16,7 @@
 #
 # Do not translate any values surrounded by {}
 
-blurb=Eclipse Modeling Tools\n\
+blurb=Eclipse Modeling Tools (includes Incubating components)\n\
 \n\
 Version: {featureVersion}\n\
 Build id: {0}\n\

--- a/packages/org.eclipse.epp.package.modeling/plugin.xml
+++ b/packages/org.eclipse.epp.package.modeling/plugin.xml
@@ -18,7 +18,7 @@
          </property>
          <property
                name="aboutText"
-               value="Eclipse Modeling Tools&#x0A;&#x0A;Version: {1}&#x0A;Build id: {0}&#x0A;&#x0A;(c) Copyright Eclipse contributors and others 2000, 2025.  All rights reserved. Eclipse and the Eclipse logo are trademarks of the Eclipse Foundation, Inc., https://www.eclipse.org/. The Eclipse logo cannot be altered without Eclipse's permission. Eclipse logos are provided for use under the Eclipse logo and trademark guidelines, https://www.eclipse.org/logotm/. Oracle and Java are trademarks or registered trademarks of Oracle and/or its affiliates. Other names may be trademarks of their respective owners.&#x0A;&#x0A;This product includes software developed by other open source projects including the Apache Software Foundation, https://www.apache.org/.&#x0A;">
+               value="Eclipse Modeling Tools (includes Incubating components)&#x0A;&#x0A;Version: {1}&#x0A;Build id: {0}&#x0A;&#x0A;(c) Copyright Eclipse contributors and others 2000, 2025.  All rights reserved. Eclipse and the Eclipse logo are trademarks of the Eclipse Foundation, Inc., https://www.eclipse.org/. The Eclipse logo cannot be altered without Eclipse's permission. Eclipse logos are provided for use under the Eclipse logo and trademark guidelines, https://www.eclipse.org/logotm/. Oracle and Java are trademarks or registered trademarks of Oracle and/or its affiliates. Other names may be trademarks of their respective owners.&#x0A;&#x0A;This product includes software developed by other open source projects including the Apache Software Foundation, https://www.apache.org/.&#x0A;">
          </property>
          <property
                name="startupForegroundColor"


### PR DESCRIPTION
I have not been doing the check incubation step for a while because everything contains incubating components. This doesn't seem likely to change anytime soon, so I have updated RELEASING.md to reflect current state.

However, during a cross check I found that modeling did include the required incubating components warning in the feature.properties but was missing it in the product aboutText blurb. This commit remedies that too.