### PR TITLE
Fix #284 : change contribute URL

### DIFF
--- a/packages/org.eclipse.epp.package.common/src/org/eclipse/epp/common/ContributeHandler.java
+++ b/packages/org.eclipse.epp.package.common/src/org/eclipse/epp/common/ContributeHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.ui.handlers.HandlerUtil;
 
 public class ContributeHandler extends AbstractHandler {
 
-	private static final String CONTRIBUTE_URL = "https://www.eclipse.org/contribute/";
+	private static final String CONTRIBUTE_URL = "https://github.com/eclipse-ide";
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {


### PR DESCRIPTION
Contribute should be now on https://github.com/eclipse-ide