### PR TITLE
Support Plug-in Spies in All Packages

### DIFF
--- a/packages/org.eclipse.epp.package.common.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.common.feature/p2.inf
@@ -27,3 +27,11 @@ requires.1.name = org.apache.commons.logging
 requires.1.range = [1.2.0.v20151023-1447,1.2.0.v20180409-1502]
 requires.1.min = 0
 requires.1.max = 0
+
+# Ensure that the selection spy and menu spy are available in every product.
+# https://github.com/eclipse-packaging/packages/issues/294
+#
+requires.2.namespace = org.eclipse.equinox.p2.iu
+requires.2.name = org.eclipse.pde.runtime
+requires.2.greedy = true
+requires.2.optional = true


### PR DESCRIPTION
- Use a p2.inf in the common feautre to create an optional greedy dependency on org.eclipse.pde.runtime.

https://github.com/eclipse-packaging/packages/issues/294