### PR TITLE
Eliminate uses of the Platform source features

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -261,11 +261,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.pde" installMode="root"/>
       <feature id="org.eclipse.pde.spies" installMode="root"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
-      <feature id="org.eclipse.platform.source" installMode="root"/>
-      <feature id="org.eclipse.rcp.source" installMode="root"/>
-      <feature id="org.eclipse.jdt.source" installMode="root"/>
-      <feature id="org.eclipse.pde.source" installMode="root"/>
-      <feature id="org.eclipse.pde.spies.source" installMode="root"/>
+      <feature id="org.eclipse.rcp" installMode="root"/>
       <feature id="org.eclipse.buildship" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.committers.product/pom.xml
+++ b/packages/org.eclipse.epp.package.committers.product/pom.xml
@@ -27,4 +27,8 @@
   <artifactId>epp.package.committers</artifactId>
   <packaging>eclipse-repository</packaging>
 
+  <properties>
+    <install-sources>true</install-sources>
+  </properties>
+
 </project>

--- a/packages/org.eclipse.epp.package.dsl.product/pom.xml
+++ b/packages/org.eclipse.epp.package.dsl.product/pom.xml
@@ -27,4 +27,8 @@
   <artifactId>epp.package.dsl</artifactId>
   <packaging>eclipse-repository</packaging>
 
+  <properties>
+    <install-sources>true</install-sources>
+  </properties>
+
 </project>

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -258,13 +258,12 @@ United States, other countries, or both.
       <feature id="org.eclipse.epp.package.modeling.feature" version="4.36.0.qualifier"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.emf.cdo.sdk" installMode="root"/>
-      <feature id="org.eclipse.emf.compare.ide.ui.source" installMode="root"/>
-      <feature id="org.eclipse.emf.compare.source" installMode="root"/>
-      <feature id="org.eclipse.emf.compare.diagram.sirius.source" installMode="root"/>
+      <feature id="org.eclipse.emf.compare.ide.ui" installMode="root"/>
+      <feature id="org.eclipse.emf.compare" installMode="root"/>
+      <feature id="org.eclipse.emf.compare.diagram.sirius" installMode="root"/>
       <feature id="org.eclipse.emf.compare.egit" installMode="root"/>
       <feature id="org.eclipse.emf.ecoretools.design" installMode="root"/>
       <feature id="org.eclipse.emf.parsley.sdk" installMode="root"/>
-      <feature id="org.eclipse.emf.parsley.sdk.source" installMode="root"/>
       <feature id="org.eclipse.emf.sdk" installMode="root"/>
       <feature id="org.eclipse.emf.transaction.sdk" installMode="root"/>
       <feature id="org.eclipse.emf.validation.sdk" installMode="root"/>

--- a/packages/org.eclipse.epp.package.modeling.product/pom.xml
+++ b/packages/org.eclipse.epp.package.modeling.product/pom.xml
@@ -27,4 +27,8 @@
   <artifactId>epp.package.modeling</artifactId>
   <packaging>eclipse-repository</packaging>
 
+  <properties>
+    <install-sources>true</install-sources>
+  </properties>
+
 </project>

--- a/packages/org.eclipse.epp.package.rcp.feature/feature.xml
+++ b/packages/org.eclipse.epp.package.rcp.feature/feature.xml
@@ -22,7 +22,7 @@
 
    <!-- This ensures these features cannot be uninstalled. They are installed with installMode="root" in the product --> 
    <requires>
-      <import feature="org.eclipse.platform.source" version="4.0.0" match="compatible"/>
+      <import feature="org.eclipse.platform" version="4.0.0" match="compatible"/>
       <import feature="org.eclipse.jdt" version="3.0.0" match="compatible"/>
       <import feature="org.eclipse.pde" version="3.0.0" match="compatible"/>
    </requires>

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -258,8 +258,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.pde" installMode="root"/>
       <feature id="org.eclipse.pde.spies" installMode="root"/>
-      <feature id="org.eclipse.platform.source" installMode="root"/>
-      <feature id="org.eclipse.rcp.source" installMode="root"/>
+      <feature id="org.eclipse.rcp" installMode="root"/>
       <feature id="org.eclipse.buildship" installMode="root"/>
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>

--- a/packages/org.eclipse.epp.package.rcp.product/pom.xml
+++ b/packages/org.eclipse.epp.package.rcp.product/pom.xml
@@ -27,4 +27,8 @@
   <artifactId>epp.package.rcp</artifactId>
   <packaging>eclipse-repository</packaging>
 
+  <properties>
+    <install-sources>true</install-sources>
+  </properties>
+
 </project>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -256,9 +256,8 @@ United States, other countries, or both.
 
       <!-- product specific contents -->
       <feature id="org.eclipse.epp.package.scout.feature" version="4.36.0.qualifier"/>
-      <feature id="org.eclipse.help.source" installMode="root"/>
+      <feature id="org.eclipse.help" installMode="root"/>
       <feature id="org.eclipse.jdt" installMode="root"/>
-      <feature id="org.eclipse.jdt.source" installMode="root"/>
       <feature id="org.eclipse.jdt.bcoview.feature" installMode="root"/>
       <feature id="org.eclipse.jst.web_ui.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>

--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <maven.version>3.9.0</maven.version>
-    <tycho.version>4.0.12</tycho.version>
+    <tycho.version>4.0.13</tycho.version>
     <tycho.scmUrl>scm:git:https://github.com/eclipse-packaging/packages.git</tycho.scmUrl>
     <cbi.version>1.5.2</cbi.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -62,6 +62,8 @@
     <justj.epp.repository>https://download.eclipse.org/justj/epp/milestone/latest</justj.epp.repository> <!-- Keep URL in sync with Oomph setup-->
     <!-- The Justj execution enviroment for the target-platform-configuration. -->
     <execution.environment>org.eclipse.justj.openjdk.hotspot.jre.full-${execution.environment.version}</execution.environment>
+    <!-- Used by tycho-p2-director-plugin materialize-products to install all available sources in the product, which is false by default -->
+    <install-sources>false</install-sources>
   </properties>
 
   <prerequisites>
@@ -396,6 +398,9 @@
                   <goals>
                     <goal>materialize-products</goal>
                   </goals>
+                  <configuration>
+                    <installSources>${install-sources}</installSources>
+                  </configuration>
                 </execution>
                 <execution>
                   <id>archive-products</id>


### PR DESCRIPTION
- Add a new property install-sources which default to false.
- Use it to configure the installSources property of tycho-p2-director-plugin:materialize-products.
- Override the property in the products that SDK like.
- Remove the source feature from products and feature, replacing with the non-source feature where it's not redundant.