### PR TITLE
Eliminate warnings about org.eclipse.platform/LegacyIDE.e4xmi

### DIFF
--- a/packages/org.eclipse.epp.package.committers/plugin.xml
+++ b/packages/org.eclipse.epp.package.committers/plugin.xml
@@ -63,7 +63,7 @@
                value="%introDescription-samples"/>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.cpp/plugin.xml
+++ b/packages/org.eclipse.epp.package.cpp/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.dsl/plugin.xml
+++ b/packages/org.eclipse.epp.package.dsl/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.embedcpp/plugin.xml
+++ b/packages/org.eclipse.epp.package.embedcpp/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.java/plugin.xml
+++ b/packages/org.eclipse.epp.package.java/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.jee/plugin.xml
+++ b/packages/org.eclipse.epp.package.jee/plugin.xml
@@ -58,7 +58,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.modeling/plugin.xml
+++ b/packages/org.eclipse.epp.package.modeling/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.php/plugin.xml
+++ b/packages/org.eclipse.epp.package.php/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.rcp/plugin.xml
+++ b/packages/org.eclipse.epp.package.rcp/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property 
                name="cssTheme"

--- a/packages/org.eclipse.epp.package.scout/plugin.xml
+++ b/packages/org.eclipse.epp.package.scout/plugin.xml
@@ -54,7 +54,7 @@
          </property>
          <property
                name="applicationXMI"
-               value="org.eclipse.platform/LegacyIDE.e4xmi">
+               value="platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi">
          </property>
          <property
                name="cssTheme"


### PR DESCRIPTION
- The warning `An entry for org.eclipse.platform/LegacyIDE.e4xmi is required in bin.includes` can be avoided by using
`platform:/plugin/org.eclipse.platform/LegacyIDE.e4xmi` instead.