### PR TITLE
Remove localScopeCheckbox and helpActivitySupport.localScopeCheckbox

### DIFF
--- a/packages/org.eclipse.epp.package.committers/plugin.properties
+++ b/packages/org.eclipse.epp.package.committers/plugin.properties
@@ -56,7 +56,6 @@ is currently disabled. It may refer to user interface elements that are \
 not visible.<br><br>\
 To manually enable capabilities, use\
 &nbsp;<a href='ACTIVITY_EDITOR'>Capabilities preference page.</a>
-helpActivitySupport.localScopeCheckbox = Show search hits from disabled capabilities
 
 TriggerPointAdvisor.proceedMulti = Enable the selected capabilities?
 TriggerPointAdvisor.proceedSingle = Enable the required capability?

--- a/packages/org.eclipse.epp.package.committers/plugin.xml
+++ b/packages/org.eclipse.epp.package.committers/plugin.xml
@@ -347,9 +347,6 @@
                pluginId="org.eclipse.help.ui">
             %helpActivitySupport.documentMessage
          </documentMessage>
-         <localScopeCheckbox>
-            %helpActivitySupport.localScopeCheckbox
-         </localScopeCheckbox>
       </support>
    </extension>
 


### PR DESCRIPTION
- According to https://github.com/eclipse-platform/eclipse.platform/commit/335fd0095533316269b1612c609047707597621d the element deprecated because it is unused.

 A search shows that indeed there is no Java code reading that element.

![image](https://github.com/user-attachments/assets/fce3d104-cbca-4b1b-a7ce-523b3e554abe)
