### PR TITLE
Ensure that all products can be updated from 2025-06 to 2025-09

### DIFF
--- a/packages/org.eclipse.epp.package.committers.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.committers.feature/p2.inf
@@ -1,16 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.committers.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.committers.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/epp.p2.inf
@@ -1,23 +1,30 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.committers
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse Committers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+# Require the fake IUs defined in the p2.inf of org.eclipse.epp.package.common.feature's
+
+requires.1.namespace = org.eclipse.equinox.p2.iu
+requires.1.name = org.eclipse.platform.source.feature.group
+requires.1.optional = true
+
+requires.2.namespace = org.eclipse.equinox.p2.iu
+requires.2.name = org.eclipse.rcp.source.feature.group
+requires.2.optional = true
+
+requires.3.namespace = org.eclipse.equinox.p2.iu
+requires.3.name = org.eclipse.jdt.source.feature.group
+requires.3.optional = true
+
+requires.4.namespace = org.eclipse.equinox.p2.iu
+requires.4.name = org.eclipse.pde.source.feature.group
+requires.4.optional = true
+
+requires.5.namespace = org.eclipse.equinox.p2.iu
+requires.5.name = org.eclipse.pde.spies.source.feature.group
+requires.5.optional = true

--- a/packages/org.eclipse.epp.package.common.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.common.feature/p2.inf
@@ -35,3 +35,83 @@ requires.2.namespace = org.eclipse.equinox.p2.iu
 requires.2.name = org.eclipse.pde.runtime
 requires.2.greedy = true
 requires.2.optional = true
+
+# Provide fake IUs for the source features that have been removed from the Platform but were installed in packages.
+
+units.1.id = org.eclipse.platform.source.feature.group
+units.1.version = 4.37.0
+units.1.update.id = org.eclipse.platform.source.feature.group
+units.1.properties.0.name = org.eclipse.equinox.p2.name
+units.1.properties.0.value = Eclipse Platform Developer Resources - Placeholder
+units.1.properties.1.name =  org.eclipse.equinox.p2.provider
+units.1.properties.1.value = Eclipse Packaging Project
+units.1.properties.2.name =  org.eclipse.equinox.p2.description
+units.1.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.1.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.1.provides.0.name = org.eclipse.platform.source.feature.group
+units.1.provides.0.version = 4.37.0
+
+units.2.id = org.eclipse.rcp.source.feature.group
+units.2.version = 4.37.0
+units.2.update.id = org.eclipse.rcp.source.feature.group
+units.2.properties.0.name = org.eclipse.equinox.p2.name
+units.2.properties.0.value = Eclipse RCP Developer Resources - Placeholder
+units.2.properties.1.name =  org.eclipse.equinox.p2.provider
+units.2.properties.1.value = Eclipse Packaging Project
+units.2.properties.2.name =  org.eclipse.equinox.p2.description
+units.2.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.2.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.2.provides.0.name = org.eclipse.rcp.source.feature.group
+units.2.provides.0.version = 4.37.0
+
+units.3.id = org.eclipse.jdt.source.feature.group
+units.3.version = 3.20.300
+units.3.update.id = org.eclipse.jdt.source.feature.group
+units.3.properties.0.name = org.eclipse.equinox.p2.name
+units.3.properties.0.value = Eclipse JDT Plug-in Developer Resources - Placeholder
+units.3.properties.1.name =  org.eclipse.equinox.p2.provider
+units.3.properties.1.value = Eclipse Packaging Project
+units.3.properties.2.name =  org.eclipse.equinox.p2.description
+units.3.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.3.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.3.provides.0.name = org.eclipse.jdt.source.feature.group
+units.3.provides.0.version = 3.20.300
+
+units.4.id = org.eclipse.pde.source.feature.group
+units.4.version = 3.16.400
+units.4.update.id = org.eclipse.pde.source.feature.group
+units.4.properties.0.name = org.eclipse.equinox.p2.name
+units.4.properties.0.value = Eclipse Plug-in Development Environment Developer Resources - Placeholder
+units.4.properties.1.name =  org.eclipse.equinox.p2.provider
+units.4.properties.1.value = Eclipse Packaging Project
+units.4.properties.2.name =  org.eclipse.equinox.p2.description
+units.4.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.4.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.4.provides.0.name = org.eclipse.pde.source.feature.group
+units.4.provides.0.version = 3.16.400
+
+units.5.id = org.eclipse.pde.spies.source.feature.group
+units.5.version = 1.0.800
+units.5.update.id = org.eclipse.pde.spies.source.feature.group
+units.5.properties.0.name = org.eclipse.equinox.p2.name
+units.5.properties.0.value = Eclipse Plug-in Development Environment Spies Developer Resources - Placeholder
+units.5.properties.1.name =  org.eclipse.equinox.p2.provider
+units.5.properties.1.value = Eclipse Packaging Project
+units.5.properties.2.name =  org.eclipse.equinox.p2.description
+units.5.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.5.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.5.provides.0.name = org.eclipse.pde.spies.source.feature.group
+units.5.provides.0.version = 1.0.800
+
+units.6.id = org.eclipse.help.source.feature.group
+units.6.version = 2.3.2300
+units.6.update.id = org.eclipse.help.source.feature.group
+units.6.properties.0.name = org.eclipse.equinox.p2.name
+units.6.properties.0.value = Eclipse Help System Developer Resources - Placeholder
+units.6.properties.1.name =  org.eclipse.equinox.p2.provider
+units.6.properties.1.value = Eclipse Packaging Project
+units.6.properties.2.name =  org.eclipse.equinox.p2.description
+units.6.properties.2.value = An empty placeholder to allow updates for the discontinued source feature.
+units.6.provides.0.namespace = org.eclipse.equinox.p2.iu
+units.6.provides.0.name = org.eclipse.help.source.feature.group
+units.6.provides.0.version = 2.3.2300

--- a/packages/org.eclipse.epp.package.cpp.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.cpp.feature/p2.inf
@@ -21,20 +21,6 @@ requires.5.namespace=org.eclipse.equinox.p2.iu
 requires.5.name=org.eclipse.linuxtools.callgraph.feature.feature.group
 requires.5.optional=true
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.cpp.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 instructions.configure=\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:0,location:http${#58}//download.eclipse.org/releases/latest);\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:1,location:http${#58}//download.eclipse.org/releases/latest);\

--- a/packages/org.eclipse.epp.package.cpp.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.cpp
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse C/C++ Developers Developers package.
 

--- a/packages/org.eclipse.epp.package.dsl.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.feature/p2.inf
@@ -1,16 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.dsl.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.dsl.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.dsl
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse DSL Tools package.
 

--- a/packages/org.eclipse.epp.package.java.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.java.feature/p2.inf
@@ -1,16 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.java.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.java.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.java.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.java
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse Java Developers package.
 

--- a/packages/org.eclipse.epp.package.jee.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.jee.feature/p2.inf
@@ -1,20 +1,6 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.jee.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 instructions.configure=\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:0,location:http${#58}//download.eclipse.org/releases/latest);\
 org.eclipse.equinox.p2.touchpoint.eclipse.removeRepository(type:1,location:http${#58}//download.eclipse.org/releases/latest);\

--- a/packages/org.eclipse.epp.package.jee.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.jee.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.jee
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse Enterprise Java and Web Developers package.
 

--- a/packages/org.eclipse.epp.package.modeling.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.feature/p2.inf
@@ -1,17 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.modeling.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-

--- a/packages/org.eclipse.epp.package.modeling.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.modeling
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse Modeling Tools package.
 

--- a/packages/org.eclipse.epp.package.php.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.php.feature/p2.inf
@@ -1,16 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.php.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.php.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.php.product/epp.p2.inf
@@ -1,21 +1,6 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.php
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse PHP Developers package.
 

--- a/packages/org.eclipse.epp.package.rcp.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.feature/p2.inf
@@ -1,18 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-#
-# RCP/RAP package had been changed in Eclipse Mars (4.5)
-
-update.id = org.eclipse.epp.package.rcp.feature.feature.group
-update.range = [4.5, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Mars (4.5) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.rcp.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.p2.inf
@@ -1,23 +1,18 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.rcp
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse RCP/RAP Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+# Require the fake IUs defined in the p2.inf of org.eclipse.epp.package.common.feature's
+
+requires.1.namespace = org.eclipse.equinox.p2.iu
+requires.1.name = org.eclipse.platform.source.feature.group
+requires.1.optional = true
+
+requires.2.namespace = org.eclipse.equinox.p2.iu
+requires.2.name = org.eclipse.rcp.source.feature.group
+requires.2.optional = true

--- a/packages/org.eclipse.epp.package.scout.feature/p2.inf
+++ b/packages/org.eclipse.epp.package.scout.feature/p2.inf
@@ -1,16 +1,2 @@
 # tell pde.build not to generate start levels
 org.eclipse.pde.build.append.startlevels=false
-
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-update.id = org.eclipse.epp.package.scout.feature.feature.group
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.

--- a/packages/org.eclipse.epp.package.scout.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.scout.product/epp.p2.inf
@@ -1,23 +1,18 @@
 instructions.configure=\
   mkdir(path:${installFolder}/dropins);
 
-# Bug 490515 - Prevent upgrade from old to new EPP package layout
-# https://bugs.eclipse.org/bugs/show_bug.cgi?id=490515
-#
-# With Eclipse Neon (4.6.0) all packages changed their structure from a single
-# feature to a product with multiple independent root features. Upgrades from
-# older versions to the new structure would result in an unexpected uninstall
-# of everything below the old main package feature. In order to prevent such
-# upgrades we add an artificial lower limit of the IU to the p2 metadata.
-
-# This is equivalent, but more restrictive than platform's "Restrict range so we are not an automatic update for 3.x."
-update.id = epp.package.scout
-update.range = [4.6.0.20160301-1200, $version$)
-update.severity = 0
-update.description = Eclipse package upgrade from versions before Eclipse Neon (4.6) is not possible. See bug 332989.
-
 properties.1.name = org.eclipse.equinox.p2.description
 properties.1.value = 2025-09 Release of the Eclipse Scout Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+# Require the fake IUs defined in the p2.inf of org.eclipse.epp.package.common.feature's
+
+requires.1.namespace = org.eclipse.equinox.p2.iu
+requires.1.name = org.eclipse.help.source.feature.group
+requires.1.optional = true
+
+requires.2.namespace = org.eclipse.equinox.p2.iu
+requires.2.name = org.eclipse.jdt.source.feature.group
+requires.2.optional = true


### PR DESCRIPTION
- Provide an empty source feature IU in org.eclipse.epp.package.common.feature for each source feature removed from the platform that was previously installed as a root in a product.
- Add an optional requirement to each product corresponding to a removed source feature.
- Remove all special update descriptors that are present only to prevent update from neon which is 9 years ago.

https://github.com/eclipse-packaging/packages/issues/333