### PR TITLE
Automate updating promote-a-build.sh

### DIFF
--- a/releng/org.eclipse.epp.config/org.eclipse.epp.releng.updater/src/org/eclipse/epp/releng/updater/Updater.java
+++ b/releng/org.eclipse.epp.config/org.eclipse.epp.releng.updater/src/org/eclipse/epp/releng/updater/Updater.java
@@ -220,6 +220,20 @@ public class Updater {
 					+ "\"\\s+name=\"" + SIMREL_VERSION_MATCHER + "\"", SIMREL_VERSION, SIMREL_VERSION);
 		} else if (fileName.equals("MANIFEST.MF")) {
 			apply(file, "Bundle-Version: " + PLATFORM_VERSION_MATCHER + "\\.0\\.qualifier", PLATFORM_VERSION);
+		} else if (fileName.equals("promote-a-build.sh")) {
+			var pattern = Pattern.compile("<past>(?<version>20[2-9][0-9]-(?:03|06|09|12))/R</past>(?<nl>\r?\n)EOM");
+			var content = getContent(file);
+			var matcher = pattern.matcher(content);
+			if (!matcher.find()) {
+				throw new IllegalStateException("Expecting a proper match in " + relativePathName);
+			}
+			var expectedPastVersion = getSimRelVersion(PLATFORM_VERSION, -2);
+			if (!expectedPastVersion.equals(matcher.group("version"))) {
+				var modifiedContent = content.substring(0, matcher.end("nl")) //
+						+ "<past>" + expectedPastVersion + "/R</past>" + matcher.group("nl")//
+						+ content.substring(matcher.end("nl"));
+				contents.put(file, modifiedContent);
+			}
 		} else if (relativePathName.equals("RELEASING.md")) {
 			// TODO
 		}

--- a/releng/org.eclipse.epp.config/tools/promote-a-build.sh
+++ b/releng/org.eclipse.epp.config/tools/promote-a-build.sh
@@ -90,6 +90,7 @@ cat > release.xml <<EOM
 <past>2024-06/R</past>
 <past>2024-09/R</past>
 <past>2024-12/R</past>
+<past>2025-03/R</past>
 EOM
 if [ "$RELEASE_MILESTONE" != "R" ]; then
   cat >> release.xml <<EOM

--- a/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
+++ b/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
@@ -59,8 +59,8 @@ cpp - 2025-06 RC2
 dsl - 2025-06 M2
 embedcpp - 2024-09 RC2
 java - 2025-06 RC1
-jee -  2025-06 RC2
-modeling - 2025-06 RC1
+jee -  2025-09 RC1
+modeling - 2025-09 RC1
 php - 2025-06 M1
 rcp - 2025-06 RC2
 scout - 2025-03 RC2
@@ -69,8 +69,8 @@ Platforms:
 Linux x86_64 - 2025-06 RC2
 Linux aarch64 - 2023-09 RC2
 Linux riscv64 - 2025-09 M2 
-Windows x86_64 - 2025-06 RC1
-Windows on Arm - 2025-06 RC2
+Windows x86_64 - 2025-09 RC1
+Windows on Arm - 2025-09 RC1
 macOS x86_64 - 2024-09 RC2
 macOS aarch64 - 2025-06 M2
 


### PR DESCRIPTION
- It should include a proper `<past></past>` that can be computed and added automatically at the start of each cycle.
- Also update upload-to-staging.sh with the most recent +1s.

https://github.com/eclipse-packaging/packages/issues/353