### PR TITLE
Ensure that the p2.statsURI properties is propagate to the aggregate

### DIFF
--- a/releng/org.eclipse.epp.config/aggregation/packaging.aggr
+++ b/releng/org.eclipse.epp.config/aggregation/packaging.aggr
@@ -2,7 +2,7 @@
 <aggregator:Aggregation xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:aggregator="http://www.eclipse.org/cbi/p2repo/2011/aggregator/1.1.0" label="EPP Packages" buildRoot="${packages.clone.location}/releng/org.eclipse.epp.config/aggregation/target/repository" excludeValidationSetUnits="true">
   <validationSets label="Main">
     <contributions label="Main">
-      <repositories location="${packages.clone.location.uri}/releng/org.eclipse.epp.config/aggregation/all-repos"/>
+      <repositories location="${packages.clone.location.uri}/releng/org.eclipse.epp.config/aggregation/all-repos" mirrorArtifactRepositoryPropertiesPattern="p2\.statsURI"/>
     </contributions>
     <validationRepositories location="${simrel.uri}"/>
     <validationRepositories location="${justj.jres.uri}"/>


### PR DESCRIPTION
The following property should be mirrored:
- https://github.com/eclipse-packaging/packages/blob/1517bd3ec6dc38f4c0eb03a1714114e701d8510d/releng/org.eclipse.epp.config/parent/pom.xml#L241