### PR TITLE
Migrate to new Eclipse Terminal namespace

### DIFF
--- a/packages/org.eclipse.epp.package.committers.product/epp.product
+++ b/packages/org.eclipse.epp.package.committers.product/epp.product
@@ -237,7 +237,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -235,7 +235,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.dsl.product/epp.product
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.product
@@ -235,7 +235,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.embedcpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.embedcpp.product/epp.product
@@ -237,7 +237,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.java.product/epp.product
+++ b/packages/org.eclipse.epp.package.java.product/epp.product
@@ -235,7 +235,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -235,7 +235,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.jee/plugin_customization.ini
+++ b/packages/org.eclipse.epp.package.jee/plugin_customization.ini
@@ -68,4 +68,4 @@ org.eclipse.equinox.p2.ui.sdk.scheduler/download=true
 org.eclipse.oomph.setup.ui/enable.preference.recorder=false
 
 # Invert colors in terminal, i.e. black background
-org.eclipse.tm.terminal.control/TerminalPrefInvertColors=true
+org.eclipse.terminal.control/TerminalPrefInvertColors=true

--- a/packages/org.eclipse.epp.package.modeling.product/epp.product
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.product
@@ -237,7 +237,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.php.product/epp.product
+++ b/packages/org.eclipse.epp.package.php.product/epp.product
@@ -237,7 +237,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.php/plugin_customization.ini
+++ b/packages/org.eclipse.epp.package.php/plugin_customization.ini
@@ -68,7 +68,7 @@ org.eclipse.oomph.setup.ui/enable.preference.recorder=false
 org.eclipse.dltk.core/org.eclipse.dltk.core.indexer.id=org.eclipse.dltk.core.index.lucene.indexer
 
 # Invert colors in terminal, i.e. black background
-org.eclipse.tm.terminal.control/TerminalPrefInvertColors=true
+org.eclipse.terminal.control/TerminalPrefInvertColors=true
 
 # Add .buildpath to the default file filtering of synchronized projects
 org.eclipse.ptp.rdt.sync.core/pattern/0/rule=-/.project

--- a/packages/org.eclipse.epp.package.rcp.product/epp.product
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.product
@@ -235,7 +235,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>

--- a/packages/org.eclipse.epp.package.scout.product/epp.product
+++ b/packages/org.eclipse.epp.package.scout.product/epp.product
@@ -237,7 +237,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.platform" installMode="root"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
-      <feature id="org.eclipse.tm.terminal.feature" installMode="root"/>
+      <feature id="org.eclipse.terminal.feature" installMode="root"/>
       <feature id="org.eclipse.justj.epp" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.jgit" installMode="root"/>


### PR DESCRIPTION
This change requires https://github.com/eclipse-platform/eclipse.platform/pull/2199 to be merged for users to get the same results when upgrading EPPs as installing new EPPs.