### PR TITLE
Persist default value for DRY_RUN when promoting build

### DIFF
--- a/releng/org.eclipse.epp.config/tools/promote-a-build.Jenkinsfile
+++ b/releng/org.eclipse.epp.config/tools/promote-a-build.Jenkinsfile
@@ -2,7 +2,7 @@
 pipeline {
   agent any
   parameters {
-    booleanParam(defaultValue: true, description: 'Do a dry run of the build. Everything will be done except the final copy to download which will be echoed', name: 'DRY_RUN')
+    booleanParam(defaultValue: false, description: 'Do a dry run of the build. Everything will be done except the final copy to download which will be echoed', name: 'DRY_RUN')
   }
   options {
     timestamps()


### PR DESCRIPTION
The decision was to make dry run off by default as it is primarily useful when testing changes to the scripts which isn't common.

The change was previously made in the [job config](https://ci.eclipse.org/packaging/job/promote-a-build/configure) on Jenkins directly, but it will be overridden on the next build because the Jenkinsfile controls that setting.

Merge after we are done with 2025-12.