### PR TITLE
Ensure products specifying installSources true really include sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,14 @@ This build creates output in two places:
 By default the maven build runs the build for all platforms.
 This can be time consuming and can be changed to only build a limited number of platforms
 which is a useful for testing changes locally.
-There is no profile (PRs welcome!) to disable other platforms.
-Instead modify `releng/org.eclipse.epp.config/parent/pom.xml` to exclude the unwanted platforms in `target-platform-configuration`'s configuration.
+The profile `single-env` can be used to build only for a single target.
+It is actived by setting these system properties.
+
+    mvn verify ... -Denv.os=linux -Denv.ws=gtk -Denv.arch=x86_64
+
+From an [m2e](https://eclipse.dev/m2e/) launch, you can use the system properties of the host:
+
+    ... -Denv.os=${system_property:osgi.os} -Denv.ws=${system_property:osgi.ws} -Denv.arch=${system_property:osgi.arch}
 
 ### Available Profiles
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -112,7 +112,7 @@ Scroll down for the per-milestone/RC steps.
   - [ ] Make sure filenames contain expected build name and milestone, e.g., `2026-03-M1`.
   - [ ] Splash screen says the expected release name with no milestone, e.g., `2026-03`.
   - [ ] `Help -> About` says the expected build name and milestone, e.g., `2026-03-M1`.
-    [ ] From the `Console`, open the `Host OSGi console` and use `ss -s INSTALLED` to verify that there are no bundles failing to resolve.
+  - [ ] From the `Console`, open the `Host OSGi console` and use `ss -s INSTALLED` to verify that there are no bundles failing to resolve.
   - [ ] The `org.eclipse.epp.package.*` features and bundles have the timestamp of the forced qualifier update or later.
   - [ ] Upgrade from previous release works.
         To test the upgrade an equivalent to the simrel release composite site needs to be done.

--- a/packages/org.eclipse.epp.package.committers.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.committers.product/epp.p2.inf
@@ -6,3 +6,6 @@ properties.1.value = 2026-03 Release of the Eclipse Committers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+properties.3.name = org.eclipse.update.install.sources
+properties.3.value = true

--- a/packages/org.eclipse.epp.package.dsl.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.dsl.product/epp.p2.inf
@@ -6,3 +6,6 @@ properties.1.value = 2026-03 Release of the Eclipse DSL Tools package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+properties.3.name = org.eclipse.update.install.sources
+properties.3.value = true

--- a/packages/org.eclipse.epp.package.modeling.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.modeling.product/epp.p2.inf
@@ -6,3 +6,6 @@ properties.1.value = 2026-03 Release of the Eclipse Modeling Tools package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+properties.3.name = org.eclipse.update.install.sources
+properties.3.value = true

--- a/packages/org.eclipse.epp.package.rcp.product/epp.p2.inf
+++ b/packages/org.eclipse.epp.package.rcp.product/epp.p2.inf
@@ -6,3 +6,6 @@ properties.1.value = 2026-03 Release of the Eclipse RCP/RAP Developers package.
 
 properties.2.name = org.eclipse.equinox.p2.provider
 properties.2.value = Eclipse Packaging Project
+
+properties.3.name = org.eclipse.update.install.sources
+properties.3.value = true

--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -243,6 +243,7 @@
             <compress>true</compress>
             <!-- Mirror goal used to aggregate unit seem to ignore the .xz files so let's not generate them to avoid inconsistency between *.jar and *.xz -->
             <xzCompress>false</xzCompress>
+            <includeAllSources>${install-sources}</includeAllSources>
           </configuration>
         </plugin>
         <plugin>
@@ -305,6 +306,7 @@
           <executions>
           </executions>
           <configuration>
+            <installSources>${install-sources}</installSources>
             <formats>
               <linux>tar.gz</linux>
               <macosx>tar.gz</macosx>
@@ -398,9 +400,6 @@
                   <goals>
                     <goal>materialize-products</goal>
                   </goals>
-                  <configuration>
-                    <installSources>${install-sources}</installSources>
-                  </configuration>
                 </execution>
                 <execution>
                   <id>archive-products</id>
@@ -413,25 +412,31 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <id>single-env</id>
+      <activation>
+        <property>
+          <name>env.os</name>
+        </property>
+      </activation>
+      <build>
         <plugins>
           <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>build-helper-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>regex-property</id>
-                <goals>
-                  <goal>regex-property</goal>
-                </goals>
-                <configuration>
-                  <name>eclipse.epp.id</name>
-                  <value>${project.artifactId}</value>
-                  <regex>epp\.package\.(\d*)</regex>
-                  <replacement>$1</replacement>
-                  <failIfNoMatch>false</failIfNoMatch>
-                </configuration>
-              </execution>
-            </executions>
+            <groupId>org.eclipse.tycho</groupId>
+            <artifactId>target-platform-configuration</artifactId>
+            <version>${tycho.version}</version>
+            <configuration>
+              <environments>
+                <environment>
+                  <os>${env.os}</os>
+                  <ws>${env.ws}</ws>
+                  <arch>${env.arch}</arch>
+                </environment>
+              </environments>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
- Move the `<installSources>` configuration from the profile to the plugin management section.
- Specify `<includeAllSources>` for the tycho-p2-repository-plugin and use the same install-sources property as used with `<installSources>` for the tycho-p2-director-plugin.
- Introduce a `single-env` profile to build only for the host environment which is useful building locally; document that in the README.md.
- Remove the build-helper-maven-plugin regex-property goal because no matches are ever found because
https://github.com/eclipse-tycho/tycho/pull/3725 is now fixed.
- Specify the IU property org.eclipse.update.install.sources=true for all the products that specify install-sources=true so that Oomph's product catalog generator can generate an p2 director task that installs source bundles.