### PR TITLE
Put back build-helper-maven-plugin regex-property

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -412,6 +412,27 @@
             </plugin>
           </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>regex-property</id>
+                <goals>
+                  <goal>regex-property</goal>
+                </goals>
+                <configuration>
+                  <name>eclipse.epp.id</name>
+                  <value>${project.artifactId}</value>
+                  <regex>epp\.package\.(\d*)</regex>
+                  <replacement>$1</replacement>
+                  <failIfNoMatch>false</failIfNoMatch>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 


### PR DESCRIPTION
- The names of the products are now eclipse-${eclipse.epp.id}-2026-03-M1-linux-gtk-aarch64.tar.gz which I is because of this change!

That property is used here:

<img width="934" height="156" alt="image" src="https://github.com/user-attachments/assets/e8330a60-f428-4d31-b530-d8f6defea0ee" />
