### PR TITLE
Back to staging

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,7 @@
 This guide contains the step-by-step process to complete an EPP release and assumes that you have an IDE provisioned using the [Oomph setup](
 https://github.com/eclipse-packaging/packages/blob/master/CONTRIBUTING.md#create-an-eclipse-development-environment).
 
-**Before** copying this file to create a new issue titled `EPP 2026-03 RC1` with label `endgame`, update the names and versions, including those in this document.
+**Before** copying this file to create a new issue titled `EPP 2026-03 RC2` with label `endgame`, update the names and versions, including those in this document.
 - [ ] To update names and versions, edit [org.eclipse.epp.releng.updater.Updater](
       releng/org.eclipse.epp.config/org.eclipse.epp.releng.updater/src/org/eclipse/epp/releng/updater/Updater.java
       ) to set the values of `MILESTONE`, `PLATFORM_VERSION`, and possibly `EXECUTION_ENVIRONMENT` to the current appropriate values.
@@ -112,9 +112,9 @@ Scroll down for the per-milestone/RC steps.
   - [ ] Use the `External Tools` toolbar button drop-down menu to launch the `Prepare Staging Sanity Check` launch configuration. 
         This will automatically download the packages specified in the launch configuration to subfolders in `/org.eclipse.epp.packages/sanity-check` to make the follow steps easier.
   - [ ] Download a package from the build's [staging output](https://download.eclipse.org/technology/epp/staging/).
-  - [ ] Make sure filenames contain expected build name and milestone, e.g., `2026-03-RC1`.
+  - [ ] Make sure filenames contain expected build name and milestone, e.g., `2026-03-R`.
   - [ ] Splash screen says the expected release name with no milestone, e.g., `2026-03`.
-  - [ ] `Help -> About` says the expected build name and milestone, e.g., `2026-03-RC1`.
+  - [ ] `Help -> About` says the expected build name and milestone, e.g., `2026-03-R`.
   - [ ] From the `Console`, open the `Host OSGi console` and use `ss -s INSTALLED` to verify that there are no bundles failing to resolve.
   - [ ] The `org.eclipse.epp.package.*` features and bundles have the timestamp of the forced qualifier update or later.
   - [ ] Upgrade from previous release works.
@@ -132,7 +132,7 @@ Scroll down for the per-milestone/RC steps.
        (especially justj, update [remove-justj-from-p2.xml](https://github.com/eclipse-packaging/packages/blob/master/releng/org.eclipse.epp.config/tools/remove-justj-from-p2.xml) if needed).
 - [ ] Edit the [Jenkins build](https://ci.eclipse.org/packaging/job/epp/job/master/lastBuild/).
   - [ ] Mark build as Keep forever.
-  - [ ] Edit Jenkins Build Information and name it, e.g., `2026-03 RC1`.
+  - [ ] Edit Jenkins Build Information and name it, e.g., `2026-03 R`.
 - [ ] Run the [Promote a Build](
       https://ci.eclipse.org/packaging/job/promote-a-build/
       ) CI job to prepare build artifacts and copy them to download.eclipse.org.
@@ -166,7 +166,7 @@ This applies to all releases, i.e. M1, M2, M3, RC1 and R.
 Everything except R is typically the Friday around 9:30am Ottawa time and the R is the following Wednesday sometime before 10am in coordination with the SimRel release engineer.
 
 - [ ] Check that this worked:
-      copy the composite\*RC1.jar files over the composite\*.jar files in https://download.eclipse.org/technology/epp/packages/2026-03/ -
+      copy the composite\*R.jar files over the composite\*.jar files in https://download.eclipse.org/technology/epp/packages/2026-03/ -
       this is done automatically with the
       [EPP Make Visible job](https://ci.eclipse.org/packaging/job/epp-makeVisible/)
       which is automatically triggered by SimRel's

--- a/packages/org.eclipse.epp.package.committers.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.committers.feature/epp.website.xml
@@ -34,6 +34,6 @@ Click <a href="https://github.com/eclipse-egit/egit/issues">here</a> to open a b
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-committers-2026-03-RC1" />
+  <product name="eclipse-committers-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.cpp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.cpp.feature/epp.website.xml
@@ -22,6 +22,6 @@
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-cpp-2026-03-RC1" />
+  <product name="eclipse-cpp-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.dsl.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.dsl.feature/epp.website.xml
@@ -27,6 +27,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-dsl-2026-03-RC1" />
+  <product name="eclipse-dsl-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.embedcpp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.embedcpp.feature/epp.website.xml
@@ -29,6 +29,6 @@ To avoid compatibility issues with pre 6.x plug-ins, it is recommended to <b>cre
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-embedcpp-2026-03-RC1" />
+  <product name="eclipse-embedcpp-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.java.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.java.feature/epp.website.xml
@@ -28,6 +28,6 @@
 
 
 	<!-- name, the name of the product, used in naming the created files. -->
-	<product name="eclipse-java-2026-03-RC1" />
+	<product name="eclipse-java-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.jee.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.jee.feature/epp.website.xml
@@ -34,6 +34,6 @@ Click <a href="https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issu
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-jee-2026-03-RC1" />
+  <product name="eclipse-jee-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.modeling.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.modeling.feature/epp.website.xml
@@ -24,6 +24,6 @@
   </packageMetaData>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-modeling-2026-03-RC1" />
+  <product name="eclipse-modeling-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.php.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.php.feature/epp.website.xml
@@ -32,6 +32,6 @@ Click <a href="https://github.com/eclipse-wildwebdeveloper/wildwebdeveloper/issu
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-php-2026-03-RC1" />
+  <product name="eclipse-php-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.rcp.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.rcp.feature/epp.website.xml
@@ -27,6 +27,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-rcp-2026-03-RC1" />
+  <product name="eclipse-rcp-2026-03-R" />
 
 </configuration>

--- a/packages/org.eclipse.epp.package.scout.feature/epp.website.xml
+++ b/packages/org.eclipse.epp.package.scout.feature/epp.website.xml
@@ -31,6 +31,6 @@
   </MoreInfo>
 
   <!-- name, the name of the product, used in naming the created files. -->
-  <product name="eclipse-scout-2026-03-RC1" />
+  <product name="eclipse-scout-2026-03-R" />
 
 </configuration>

--- a/releng/org.eclipse.epp.config/org.eclipse.epp.releng.updater/src/org/eclipse/epp/releng/updater/Updater.java
+++ b/releng/org.eclipse.epp.config/org.eclipse.epp.releng.updater/src/org/eclipse/epp/releng/updater/Updater.java
@@ -39,7 +39,7 @@ public class Updater {
 	/**
 	 * M1, M2, M3, RC1, RC2
 	 */
-	private static final String MILESTONE = "RC1";
+	private static final String MILESTONE = "RC2";
 
 	private static final String PLATFORM_VERSION = "4.39";
 

--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -35,13 +35,13 @@
     <PREV_RELEASE_NAME>2025-12</PREV_RELEASE_NAME>
     <NEXT_RELEASE_NAME>2026-06</NEXT_RELEASE_NAME>
     <!-- Name of the milestone -->
-    <RELEASE_MILESTONE>RC1</RELEASE_MILESTONE>
+    <RELEASE_MILESTONE>R</RELEASE_MILESTONE>
     <!-- Version of the release -->
     <RELEASE_VERSION>4.39.0</RELEASE_VERSION>
     <!-- Name release directory on download.eclipse.org -->
-    <RELEASE_DIR>202602261000</RELEASE_DIR>
+    <RELEASE_DIR>202603051000</RELEASE_DIR>
     <!-- SimRel Repo to build from -->
-    <SIMREL_REPO>https://download.eclipse.org/releases/2026-03/202602271000/</SIMREL_REPO>
+    <SIMREL_REPO>https://download.eclipse.org/staging/2026-03/</SIMREL_REPO>
     <!-- ID used to generate the filename of the packages -->
     <eclipse.simultaneous.release.id>${RELEASE_NAME}-${RELEASE_MILESTONE}</eclipse.simultaneous.release.id>
     <!-- Timestamp used in various places, e.g. the about dialog (see about.mappings) -->
@@ -51,7 +51,7 @@
     <!-- eclipse.simultaneous.release.name value for non-R builds -->
     <!-- <eclipse.simultaneous.release.name>${RELEASE_NAME} ${RELEASE_MILESTONE} (${RELEASE_VERSION} ${RELEASE_MILESTONE})</eclipse.simultaneous.release.name> -->
     <!-- eclipse.simultaneous.release.name value for R builds -->
-    <eclipse.simultaneous.release.name>${RELEASE_NAME} ${RELEASE_MILESTONE} (${RELEASE_VERSION} ${RELEASE_MILESTONE})</eclipse.simultaneous.release.name>
+    <eclipse.simultaneous.release.name>${RELEASE_NAME} (${RELEASE_VERSION})</eclipse.simultaneous.release.name>
     <!-- Upstream p2 repository, used as a source for pre-compiled build artifacts -->
     <eclipse.simultaneous.release.repository>${SIMREL_REPO}</eclipse.simultaneous.release.repository>
     <!-- Used for the variable below to update easily, e.g., to 21. -->

--- a/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
+++ b/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
@@ -63,7 +63,7 @@ dsl - 2026-03 M3
 embedcpp - 2026-03 M2
 java - 2025-06 RC1
 jee -  2026-03 M3
-modeling - 2026-03 M2
+modeling - 2026-03 RC1
 php - 2025-12 RC1 
 rcp - 2025-06 RC2
 scout - 2026-03 M3
@@ -72,7 +72,7 @@ Platforms:
 Linux x86_64 - 2026-03 M2
 Linux aarch64 - 2023-09 RC2
 Linux riscv64 - 2025-12 M1 
-Windows x86_64 - 2026-03 M2
+Windows x86_64 - 2026-03 RC1
 Windows on Arm - 2025-12 RC1
 macOS x86_64 - 2026-03 M1
 macOS aarch64 - 2026-03- M3


### PR DESCRIPTION
- Use https://download.eclipse.org/staging/2026-03/
- Update versions to RC2, i.e., R

Part of https://github.com/eclipse-packaging/packages/issues/422