### PR TITLE
Add LLDB feature of CDT to EPP for C/C++ users

### DIFF
--- a/packages/org.eclipse.epp.package.cpp.product/epp.product
+++ b/packages/org.eclipse.epp.package.cpp.product/epp.product
@@ -281,6 +281,7 @@ United States, other countries, or both.
       <feature id="org.eclipse.cdt.debug.ui.memory" installMode="root"/>
       <feature id="org.eclipse.cdt.launch.remote" installMode="root"/>
       <feature id="org.eclipse.cdt.launch.serial.feature" installMode="root"/>
+      <feature id="org.eclipse.cdt.llvm.dsf.lldb" installMode="root"/>
       <feature id="org.eclipse.cdt.managedbuilder.llvm" installMode="root"/>
       <feature id="org.eclipse.cdt.testsrunner.feature" installMode="root"/>
       <feature id="org.eclipse.cdt.lsp.feature" installMode="root"/>


### PR DESCRIPTION
This simplifies debugging for CDT users on macOS when doing native (host) debugging.

This is a continuation of the work done in https://github.com/eclipse-packaging/packages/pull/345 and was discussed/approved at the [recent CDT call](https://github.com/eclipse-cdt/cdt/discussions/1442#discussioncomment-16491421)