### PR TITLE
Remove org.eclipse.m2e.wtp from the JEE product

### DIFF
--- a/packages/org.eclipse.epp.package.jee.product/epp.product
+++ b/packages/org.eclipse.epp.package.jee.product/epp.product
@@ -339,10 +339,6 @@ United States, other countries, or both.
       <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
       <!-- either m2e.logback or slf4j.simple should be provided in each package -->
       <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.wtp.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.wtp.jaxrs.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.wtp.jpa.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.wtp.jsf.feature" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.pde" installMode="root"/>
       <feature id="org.eclipse.wst.common.fproj" installMode="root"/>


### PR DESCRIPTION
- The providing repository is basically dead https://github.com/eclipse-m2e/m2e-wtp so it either needs some life support or the contribution needs to be removed from SimRel.