### PR TITLE
Prepare for 2026-09 M2

### DIFF
--- a/releng/org.eclipse.epp.config/parent/pom.xml
+++ b/releng/org.eclipse.epp.config/parent/pom.xml
@@ -41,7 +41,7 @@
     <!-- Name release directory on download.eclipse.org -->
     <RELEASE_DIR>202607301000</RELEASE_DIR>
     <!-- SimRel Repo to build from -->
-    <SIMREL_REPO>https://download.eclipse.org/staging/2026-09/</SIMREL_REPO>
+    <SIMREL_REPO>https://download.eclipse.org/releases/2026-09/202607311000/</SIMREL_REPO>
     <!-- ID used to generate the filename of the packages -->
     <eclipse.simultaneous.release.id>${RELEASE_NAME}-${RELEASE_MILESTONE}</eclipse.simultaneous.release.id>
     <!-- Timestamp used in various places, e.g., the about dialog (see about.mappings) -->

--- a/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
+++ b/releng/org.eclipse.epp.config/tools/upload-to-staging.sh
@@ -63,7 +63,7 @@ dsl - 2026-06 RC1
 embedcpp - 2026-03 M2
 java - 2025-06 RC1
 jee -  2026-06 RC2
-modeling - 2026-06 RC2
+modeling - 2026-09 M1
 php - 2025-12 RC1 
 rcp - 2025-06 RC2
 scout - 2026-03 M3
@@ -72,7 +72,7 @@ Platforms:
 Linux x86_64 - 2026-06 RC1
 Linux aarch64 - 2023-09 RC2
 Linux riscv64 - 2025-12 M1 
-Windows x86_64 - 2026-06 RC2
+Windows x86_64 - 2026-09 M1
 Windows on Arm - 2026-06 RC2
 macOS x86_64 - 2026-03 M1
 macOS aarch64 - 2026-06- RC1


### PR DESCRIPTION
- Use https://download.eclipse.org/releases/2026-09/202607311000/

Part of https://github.com/eclipse-packaging/packages/issues/456